### PR TITLE
Fix bug build beacon instructions with different block height

### DIFF
--- a/blockchain/beaconbridgeproducer.go
+++ b/blockchain/beaconbridgeproducer.go
@@ -19,7 +19,6 @@ import (
 func (blockChain *BlockChain) buildBridgeInstructions(
 	shardID byte,
 	shardBlockInstructions [][]string,
-	// beaconBestState *BeaconBestState
 	beaconHeight uint64,
 	db database.DatabaseInterface,
 ) ([][]string, error) {
@@ -29,7 +28,6 @@ func (blockChain *BlockChain) buildBridgeInstructions(
 		CBridgeTokens:    []*common.Hash{},
 	}
 	instructions := [][]string{}
-	//beaconHeight := beaconBestState.BeaconHeight
 	for _, inst := range shardBlockInstructions {
 		if len(inst) < 2 {
 			continue
@@ -56,7 +54,7 @@ func (blockChain *BlockChain) buildBridgeInstructions(
 
 		case metadata.BurningRequestMeta:
 			burningConfirm := []string{}
-			burningConfirm, err = buildBurningConfirmInst(inst, beaconHeight+1, db)
+			burningConfirm, err = buildBurningConfirmInst(inst, beaconHeight, db)
 			newInst = [][]string{burningConfirm}
 
 		default:

--- a/blockchain/beaconprocess.go
+++ b/blockchain/beaconprocess.go
@@ -160,7 +160,7 @@ func (blockchain *BlockChain) verifyPreProcessingBeaconBlock(beaconBlock *Beacon
 	blockchain.BestState.Beacon.lock.RLock()
 	defer blockchain.BestState.Beacon.lock.RUnlock()
 	if len(beaconBlock.Header.ProducerAddress.Bytes()) != 66 {
-		return NewBlockChainError(ProducerError, fmt.Errorf("Expect %+v has length 66 but get %+v", len(beaconBlock.Header.ProducerAddress.Bytes())))
+		return NewBlockChainError(ProducerError, fmt.Errorf("Expect has length 66 but get %+v", len(beaconBlock.Header.ProducerAddress.Bytes())))
 	}
 	//verify version
 	if beaconBlock.Header.Version != BEACON_BLOCK_VERSION {
@@ -332,7 +332,7 @@ func (blockchain *BlockChain) verifyPreProcessingBeaconBlockForSigning(beaconBlo
 		return NewBlockChainError(GenerateInstructionHashError, fmt.Errorf("Fail to generate hash for instruction %+v", tempInstructionArr))
 	}
 	if !tempInstructionHash.IsEqual(&beaconBlock.Header.InstructionHash) {
-		return NewBlockChainError(InstructionHashError, fmt.Errorf("Expect Instruction Hash in Beacon Header to be %+v, but get %+v", beaconBlock.Header.InstructionHash, tempInstructionHash))
+		return NewBlockChainError(InstructionHashError, fmt.Errorf("Expect Instruction Hash in Beacon Header to be %+v, but get %+v, validator instructions: %+v", beaconBlock.Header.InstructionHash, tempInstructionHash, tempInstruction))
 	}
 	return nil
 }

--- a/blockchain/beaconproducer.go
+++ b/blockchain/beaconproducer.go
@@ -2,12 +2,13 @@ package blockchain
 
 import (
 	"fmt"
-	"github.com/incognitochain/incognito-chain/privacy"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/incognitochain/incognito-chain/privacy"
 
 	"github.com/incognitochain/incognito-chain/common"
 	"github.com/incognitochain/incognito-chain/incognitokey"
@@ -76,7 +77,7 @@ func (blockGenerator *BlockGenerator) NewBlockBeacon(producerAddress *privacy.Pa
 	beaconBlock.Header.Epoch = epoch
 	beaconBlock.Header.Round = round
 	beaconBlock.Header.PreviousBlockHash = beaconBestState.BestBlockHash
-	BLogger.log.Infof("Producing block: %d, %d", beaconBlock.Header.Height, beaconBlock.Header.Epoch)
+	BLogger.log.Infof("Producing block: %d (epoch %d)", beaconBlock.Header.Height, beaconBlock.Header.Epoch)
 	//=====END Build Header Essential Data=====
 	//============Build body===================
 	tempShardState, staker, swap, bridgeInstructions, acceptedRewardInstructions := blockGenerator.GetShardState(beaconBestState, shardsToBeaconLimit)
@@ -88,6 +89,9 @@ func (blockGenerator *BlockGenerator) NewBlockBeacon(producerAddress *privacy.Pa
 	beaconBlock.Body.ShardState = tempShardState
 	if len(beaconBlock.Body.Instructions) != 0 {
 		Logger.log.Info("Beacon Produce: Beacon Instruction", beaconBlock.Body.Instructions)
+	}
+	if len(bridgeInstructions) > 0 {
+		BLogger.log.Infof("Producer instructions: %+v", tempInstruction)
 	}
 	//============End Build Body================
 	//============Build Header Hash=============
@@ -217,7 +221,7 @@ func (blockGenerator *BlockGenerator) GetShardState(beaconBestState *BeaconBestS
 			totalBlock = MAX_S2B_BLOCK
 		}
 		for _, shardBlock := range shardBlocks[:totalBlock+1] {
-			shardState, validStakeInstruction, validSwapInstruction, bridgeInstruction, acceptedRewardInstruction := blockGenerator.chain.GetShardStateFromBlock(beaconBestState.BeaconHeight, shardBlock, shardID)
+			shardState, validStakeInstruction, validSwapInstruction, bridgeInstruction, acceptedRewardInstruction := blockGenerator.chain.GetShardStateFromBlock(beaconBestState.BeaconHeight+1, shardBlock, shardID)
 			shardStates[shardID] = append(shardStates[shardID], shardState[shardID])
 			validStakeInstructions = append(validStakeInstructions, validStakeInstruction...)
 			validSwapInstructions[shardID] = append(validSwapInstructions[shardID], validSwapInstruction[shardID]...)

--- a/blockchain/burn_test.go
+++ b/blockchain/burn_test.go
@@ -284,7 +284,7 @@ func TestBuildBridgeInst(t *testing.T) {
 		{
 			desc:  "ERC20",
 			insts: [][]string{setupBurningRequest(2)},
-			out:   [][]string{setupBurningConfirmInst(int64(height)+1, token[:])},
+			out:   [][]string{setupBurningConfirmInst(int64(height), token[:])},
 		},
 	}
 
@@ -294,7 +294,7 @@ func TestBuildBridgeInst(t *testing.T) {
 			insts, err := bc.buildBridgeInstructions(
 				0,
 				tc.insts,
-				&BeaconBestState{BeaconHeight: height},
+				height,
 				setupDB(t),
 			)
 			if err != nil {

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -127,6 +127,7 @@ const (
 	StoreBeaconBestStateError
 	StoreBeaconBlockError
 	StoreBeaconBlockIndexError
+	StoreCommitteeFromShardBestStateError
 )
 
 var ErrCodeMessage = map[int]struct {
@@ -238,6 +239,7 @@ var ErrCodeMessage = map[int]struct {
 	ShuffleBeaconCandidateError:                       {-1103, "Shuffle Beacon Candidate Error"},
 	CleanBackUpError:                                  {-1104, "Clean Back Up Error"},
 	BackUpBestStateError:                              {-1105, "Back Up Best State Error"},
+	StoreCommitteeFromShardBestStateError:             {-1106, "Store Committee From ShardBestState Error"},
 }
 
 type BlockChainError struct {

--- a/mocks/DatabaseInterface.go
+++ b/mocks/DatabaseInterface.go
@@ -801,6 +801,27 @@ func (_m *DatabaseInterface) GetBlockByIndex(_a0 uint64, _a1 byte) (common.Hash,
 	return r0, r1
 }
 
+// GetBridgeReqWithStatus provides a mock function with given fields: txReqID
+func (_m *DatabaseInterface) GetBridgeReqWithStatus(txReqID common.Hash) (byte, error) {
+	ret := _m.Called(txReqID)
+
+	var r0 byte
+	if rf, ok := ret.Get(0).(func(common.Hash) byte); ok {
+		r0 = rf(txReqID)
+	} else {
+		r0 = ret.Get(0).(byte)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(common.Hash) error); ok {
+		r1 = rf(txReqID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetBurningConfirm provides a mock function with given fields: txID
 func (_m *DatabaseInterface) GetBurningConfirm(txID []byte) (uint64, error) {
 	ret := _m.Called(txID)
@@ -1785,20 +1806,6 @@ func (_m *DatabaseInterface) StoreCommitments(tokenID common.Hash, pubkey []byte
 	return r0
 }
 
-// StoreShardCommitteeByHeight provides a mock function with given fields: _a0, _a1
-func (_m *DatabaseInterface) StoreShardCommitteeByHeight(_a0 uint64, _a1 interface{}) error {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(uint64, interface{}) error); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // StoreCommitteeFromShardBestState provides a mock function with given fields: shardID, shardHeight, v
 func (_m *DatabaseInterface) StoreCommitteeFromShardBestState(shardID byte, shardHeight uint64, v interface{}) error {
 	ret := _m.Called(shardID, shardHeight, v)
@@ -2023,6 +2030,20 @@ func (_m *DatabaseInterface) StoreShardBlockIndex(_a0 common.Hash, _a1 uint64, _
 	return r0
 }
 
+// StoreShardCommitteeByHeight provides a mock function with given fields: _a0, _a1
+func (_m *DatabaseInterface) StoreShardCommitteeByHeight(_a0 uint64, _a1 interface{}) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(uint64, interface{}) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // StoreTransactionIndex provides a mock function with given fields: txId, blockHash, indexInBlock
 func (_m *DatabaseInterface) StoreTransactionIndex(txId common.Hash, blockHash common.Hash, indexInBlock int) error {
 	ret := _m.Called(txId, blockHash, indexInBlock)
@@ -2044,6 +2065,20 @@ func (_m *DatabaseInterface) StoreTxByPublicKey(publicKey []byte, txID common.Ha
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]byte, common.Hash, byte) error); ok {
 		r0 = rf(publicKey, txID, shardID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// TrackBridgeReqWithStatus provides a mock function with given fields: txReqID, status
+func (_m *DatabaseInterface) TrackBridgeReqWithStatus(txReqID common.Hash, status byte) error {
+	ret := _m.Called(txReqID, status)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(common.Hash, byte) error); ok {
+		r0 = rf(txReqID, status)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
- Pass new beacon block height to GetShardStateFromBlock
- buildBridgeInstruction builds BurningConfirm with new beacon block
height (no increasing by one)
- Re-enable StoreCommitteeFromShardBestState
- Log instructions of beacon producer and validators