### PR TITLE
Add configuration for centralized logging system

### DIFF
--- a/bin/centralized-logging/elk/docker-compose.yml
+++ b/bin/centralized-logging/elk/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3.2'
+
+services:
+  elasticsearch:
+    build:
+      context: elasticsearch/
+      args:
+        ELK_VERSION: $ELK_VERSION
+    volumes:
+      - type: bind
+        source: ./elasticsearch/config/elasticsearch.yml
+        target: /usr/share/elasticsearch/config/elasticsearch.yml
+        read_only: true
+      - type: bind
+        source: ./elasticsearch/data
+        target: /usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      ES_JAVA_OPTS: "-Xmx2g -Xms2g"
+      #ELASTIC_PASSWORD: changeme
+    networks:
+      - elk
+
+  logstash:
+    build:
+      context: logstash/
+      args:
+        ELK_VERSION: $ELK_VERSION
+    volumes:
+      - type: bind
+        source: ./logstash/config/logstash.yml
+        target: /usr/share/logstash/config/logstash.yml
+        read_only: true
+      - type: bind
+        source: ./logstash/pipeline
+        target: /usr/share/logstash/pipeline
+        read_only: true
+    ports:
+      - "5000:5000"
+      - "9600:9600"
+    environment:
+      LS_JAVA_OPTS: "-Xmx256m -Xms256m"
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+
+  kibana:
+    build:
+      context: kibana/
+      args:
+        ELK_VERSION: $ELK_VERSION
+    volumes:
+      - type: bind
+        source: ./kibana/config/kibana.yml
+        target: /usr/share/kibana/config/kibana.yml
+        read_only: true
+    ports:
+      - "5601:5601"
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+
+networks:
+  elk:
+    driver: bridge
+
+# volumes:
+#   elasticsearch:

--- a/bin/centralized-logging/elk/docker-stack.yml
+++ b/bin/centralized-logging/elk/docker-stack.yml
@@ -1,0 +1,66 @@
+version: '3.3'
+
+services:
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.1
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    configs:
+      - source: elastic_config
+        target: /usr/share/elasticsearch/config/elasticsearch.yml
+    environment:
+      ES_JAVA_OPTS: "-Xmx256m -Xms256m"
+      ELASTIC_PASSWORD: changeme
+    networks:
+      - elk
+    deploy:
+      mode: replicated
+      replicas: 1
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:7.3.1
+    ports:
+      - "5000:5000"
+      - "9600:9600"
+    configs:
+      - source: logstash_config
+        target: /usr/share/logstash/config/logstash.yml
+      - source: logstash_pipeline
+        target: /usr/share/logstash/pipeline/logstash.conf
+    environment:
+      LS_JAVA_OPTS: "-Xmx256m -Xms256m"
+    networks:
+      - elk
+    deploy:
+      mode: replicated
+      replicas: 1
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.3.1
+    ports:
+      - "5601:5601"
+    configs:
+      - source: kibana_config
+        target: /usr/share/kibana/config/kibana.yml
+    networks:
+      - elk
+    deploy:
+      mode: replicated
+      replicas: 1
+
+configs:
+
+  elastic_config:
+    file: ./elasticsearch/config/elasticsearch.yml
+  logstash_config:
+    file: ./logstash/config/logstash.yml
+  logstash_pipeline:
+    file: ./logstash/pipeline/logstash.conf
+  kibana_config:
+    file: ./kibana/config/kibana.yml
+
+networks:
+  elk:
+    driver: overlay

--- a/bin/centralized-logging/elk/elasticsearch/Dockerfile
+++ b/bin/centralized-logging/elk/elasticsearch/Dockerfile
@@ -1,0 +1,7 @@
+ARG ELK_VERSION
+
+# https://github.com/elastic/elasticsearch-docker
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELK_VERSION}
+
+# Add your elasticsearch plugins setup here
+# Example: RUN elasticsearch-plugin install analysis-icu

--- a/bin/centralized-logging/elk/kibana/Dockerfile
+++ b/bin/centralized-logging/elk/kibana/Dockerfile
@@ -1,0 +1,7 @@
+ARG ELK_VERSION
+
+# https://github.com/elastic/kibana-docker
+FROM docker.elastic.co/kibana/kibana:${ELK_VERSION}
+
+# Add your kibana plugins setup here
+# Example: RUN kibana-plugin install <name|url>

--- a/bin/centralized-logging/elk/logstash/Dockerfile
+++ b/bin/centralized-logging/elk/logstash/Dockerfile
@@ -1,0 +1,8 @@
+ARG ELK_VERSION
+
+# https://github.com/elastic/logstash-docker
+FROM docker.elastic.co/logstash/logstash:${ELK_VERSION}
+
+# Add your logstash plugins setup here
+# Example: RUN logstash-plugin install logstash-filter-json
+RUN logstash-plugin install logstash-input-beats

--- a/bin/centralized-logging/elk/logstash/pipeline/logstash.conf
+++ b/bin/centralized-logging/elk/logstash/pipeline/logstash.conf
@@ -1,0 +1,16 @@
+input {
+	beats {
+		port => 5000
+	}
+}
+
+## Add your filters / logstash plugins configuration here
+
+output {
+	elasticsearch {
+		hosts => "elasticsearch:9200"
+		user => "elastic"
+		password => "changeme"
+		index => "%{[@metadata][beat]}-%{[@metadata][version]}"
+	}
+}

--- a/bin/centralized-logging/filebeat/Dockerfile
+++ b/bin/centralized-logging/filebeat/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.elastic.co/beats/filebeat:7.4.0
+COPY filebeat.yml /usr/share/filebeat/filebeat.yml
+USER root
+RUN chown root:filebeat /usr/share/filebeat/filebeat.yml
+USER filebeat

--- a/bin/centralized-logging/filebeat/filebeat.yml
+++ b/bin/centralized-logging/filebeat/filebeat.yml
@@ -1,0 +1,64 @@
+filebeat.inputs:
+- type: log
+  enabled: true
+  paths:
+    - /tmp/beacon0/*.json
+    - /tmp/beacon2/*.json
+  json.keys_under_root: true
+
+- type: log
+  enabled: true
+  paths:
+    - /tmp/beacon0/*.txt
+    - /tmp/beacon1/*.txt
+    - /tmp/beacon2/*.txt
+    - /tmp/beacon3/*.txt
+
+    - /tmp/shard0-0/*.txt
+    - /tmp/shard0-1/*.txt
+    - /tmp/shard0-2/*.txt
+    - /tmp/shard0-3/*.txt
+
+    - /tmp/shard1-0/*.txt
+    - /tmp/shard1-1/*.txt
+    - /tmp/shard1-2/*.txt
+    - /tmp/shard1-3/*.txt
+
+    - /tmp/shard2-0/*.txt
+    - /tmp/shard2-1/*.txt
+    - /tmp/shard2-2/*.txt
+    - /tmp/shard2-3/*.txt
+
+    - /tmp/shard3-0/*.txt
+    - /tmp/shard3-1/*.txt
+    - /tmp/shard3-2/*.txt
+    - /tmp/shard3-3/*.txt
+
+    - /tmp/shard4-0/*.txt
+    - /tmp/shard4-1/*.txt
+    - /tmp/shard4-2/*.txt
+    - /tmp/shard4-3/*.txt
+
+    - /tmp/shard5-0/*.txt
+    - /tmp/shard5-1/*.txt
+    - /tmp/shard5-2/*.txt
+    - /tmp/shard5-3/*.txt
+
+    - /tmp/shard6-0/*.txt
+    - /tmp/shard6-1/*.txt
+    - /tmp/shard6-2/*.txt
+    - /tmp/shard6-3/*.txt
+
+    - /tmp/shard7-0/*.txt
+    - /tmp/shard7-1/*.txt
+    - /tmp/shard7-2/*.txt
+    - /tmp/shard7-3/*.txt
+
+# output.logstash:
+#   hosts: ["127.0.0.1:5000"]
+#   username: "elastic",
+#   password: "changeme"
+
+output.logstash:
+  hosts: ["34.94.185.164:5000"]
+


### PR DESCRIPTION
This PR is to add configuration for a centralized logging system that is being set up with ELKB stack:
- ELK is being set up on the logging server.
- Filebeat is being set up on every single incognito node.

Currently the setup has yet supported 2 logging formats: plain text & JSON. The sample result might be shown at:
http://34.94.185.164:5601/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now%2Fd,to:now%2Fd))&_a=(columns:!(log.file.path,event,session_id,user,verified,id,ductestfield),index:c3c81180-f213-11e9-98cd-4b3eff72c77d,interval:auto,query:(language:kuery,query:'log.file.path:%20*json*'),sort:!('@timestamp',desc))