### PR TITLE
Fix the sanity validation issue for pdex withdrawal request

### DIFF
--- a/metadata/pdewithdrawalrequest.go
+++ b/metadata/pdewithdrawalrequest.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"reflect"
 	"strconv"
 
 	"github.com/incognitochain/incognito-chain/common"
@@ -70,11 +69,6 @@ func (pc PDEWithdrawalRequest) ValidateTxWithBlockChain(
 }
 
 func (pc PDEWithdrawalRequest) ValidateSanityData(bcr BlockchainRetriever, txr Transaction) (bool, bool, error) {
-	// Note: the metadata was already verified with *transaction.TxCustomToken level so no need to verify with *transaction.Tx level again as *transaction.Tx is embedding property of *transaction.TxCustomToken
-	if reflect.TypeOf(txr).String() == "*transaction.Tx" {
-		return true, true, nil
-	}
-
 	keyWallet, err := wallet.Base58CheckDeserialize(pc.WithdrawerAddressStr)
 	if err != nil {
 		return false, false, NewMetadataTxError(PDEWithdrawalRequestFromMapError, errors.New("WithdrawerAddressStr incorrect"))


### PR DESCRIPTION
The PR is to fix the sanity validation issue for pdex withdrawal request as withdrawal request tx type is always normal privacy.