### PR TITLE
Deduplicate removing liquidity txs

### DIFF
--- a/blockchain/pdetxsbuilder.go
+++ b/blockchain/pdetxsbuilder.go
@@ -229,9 +229,12 @@ func (blockGenerator *BlockGenerator) buildPDEWithdrawalTx(
 		return nil, nil
 	}
 
-	meta := metadata.NewPDEWithdrawalResponse(wdAcceptedContent.TxReqID, metadata.PDEWithdrawalResponseMeta)
-
 	withdrawalTokenIDStr := wdAcceptedContent.WithdrawalTokenIDStr
+	meta := metadata.NewPDEWithdrawalResponse(
+		withdrawalTokenIDStr,
+		wdAcceptedContent.TxReqID,
+		metadata.PDEWithdrawalResponseMeta,
+	)
 	tokenID, err := common.Hash{}.NewHashFromStr(withdrawalTokenIDStr)
 	if err != nil {
 		Logger.log.Errorf("ERROR: an error occured while converting tokenid to hash: %+v", err)
@@ -270,31 +273,15 @@ func (blockGenerator *BlockGenerator) buildPDEWithdrawalTx(
 	var propertyID [common.HashSize]byte
 	copy(propertyID[:], tokenID[:])
 	propID := common.Hash(propertyID)
-
-	// try get token name and symbol
-	listTxInitPrivacyToken, listTxInitPrivacyTokenCrossShard, err := blockGenerator.chain.ListPrivacyCustomToken()
-	_ = listTxInitPrivacyTokenCrossShard
-	tokeName := ""
-	tokenSymbol := ""
-	if txInitToken, ok := listTxInitPrivacyToken[propID]; ok {
-		// case same shard
-		tokeName = txInitToken.TxPrivacyTokenData.PropertyName
-		tokenSymbol = txInitToken.TxPrivacyTokenData.PropertySymbol
-	} else if txInitToken, ok := listTxInitPrivacyTokenCrossShard[propID]; ok {
-		// case cross shard
-		tokeName = txInitToken.PropertyName
-		tokenSymbol = txInitToken.PropertySymbol
-	}
-
 	tokenParams := &transaction.CustomTokenPrivacyParamTx{
-		PropertyID:     propID.String(),
-		PropertyName:   tokeName,
-		PropertySymbol: tokenSymbol,
-		Amount:         wdAcceptedContent.DeductingPoolValue,
-		TokenTxType:    transaction.CustomTokenInit,
-		Receiver:       []*privacy.PaymentInfo{receiver},
-		TokenInput:     []*privacy.InputCoin{},
-		Mintable:       true,
+		PropertyID: propID.String(),
+		// PropertyName:   tokeName,
+		// PropertySymbol: tokenSymbol,
+		Amount:      wdAcceptedContent.DeductingPoolValue,
+		TokenTxType: transaction.CustomTokenInit,
+		Receiver:    []*privacy.PaymentInfo{receiver},
+		TokenInput:  []*privacy.InputCoin{},
+		Mintable:    true,
 	}
 	resTx := &transaction.TxCustomTokenPrivacy{}
 	initErr := resTx.Init(

--- a/metadata/pdewithdrawalresponse.go
+++ b/metadata/pdewithdrawalresponse.go
@@ -14,9 +14,11 @@ import (
 type PDEWithdrawalResponse struct {
 	MetadataBase
 	RequestedTxID common.Hash
+	TokenIDStr    string
 }
 
 func NewPDEWithdrawalResponse(
+	tokenIDStr string,
 	requestedTxID common.Hash,
 	metaType int,
 ) *PDEWithdrawalResponse {
@@ -25,6 +27,7 @@ func NewPDEWithdrawalResponse(
 	}
 	return &PDEWithdrawalResponse{
 		RequestedTxID: requestedTxID,
+		TokenIDStr:    tokenIDStr,
 		MetadataBase:  metadataBase,
 	}
 }
@@ -50,6 +53,7 @@ func (iRes PDEWithdrawalResponse) ValidateMetadataByItself() bool {
 
 func (iRes PDEWithdrawalResponse) Hash() *common.Hash {
 	record := iRes.RequestedTxID.String()
+	record += iRes.TokenIDStr
 	record += iRes.MetadataBase.Hash().String()
 
 	// final hash


### PR DESCRIPTION
The PR is to add tokenid string to pde withdrawal response metadata in order to avoid duplicated txs.