### PR TITLE
Validate tx with correct  beacon height

### DIFF
--- a/blockchain/retrieverformetadata.go
+++ b/blockchain/retrieverformetadata.go
@@ -4,12 +4,11 @@ func (blockchain *BlockChain) GetStakingAmountShard() uint64 {
 	return blockchain.config.ChainParams.StakingAmountShard
 }
 
-func (blockchain *BlockChain) GetCentralizedWebsitePaymentAddress() string {
+func (blockchain *BlockChain) GetCentralizedWebsitePaymentAddress(beaconHeight uint64) string {
 	if blockchain.config.ChainParams.Net == Testnet {
 		return blockchain.config.ChainParams.CentralizedWebsitePaymentAddress
 	}
 	if blockchain.config.ChainParams.Net == Mainnet {
-		beaconHeight := blockchain.BeaconChain.GetFinalViewHeight()
 		if beaconHeight >= 243500 {
 			// use new address
 			return "12S6jZ6sjJaqsuMJKS6jG7gvE9eHUXGWa2B2dNC7PwyEYJkL6cE53Uzk926HrQMEv2i2oBvKP2GDTC6tzU9dYSVH5X3w9P58VWqux4F"

--- a/metadata/issuingrequest.go
+++ b/metadata/issuingrequest.go
@@ -104,7 +104,8 @@ func NewIssuingRequestFromMap(data map[string]interface{}) (Metadata, error) {
 }
 
 func (iReq IssuingRequest) ValidateTxWithBlockChain(tx Transaction, chainRetriever ChainRetriever, shardViewRetriever ShardViewRetriever, beaconViewRetriever BeaconViewRetriever, shardID byte, transactionStateDB *statedb.StateDB) (bool, error) {
-	keySet, err := wallet.Base58CheckDeserialize(chainRetriever.GetCentralizedWebsitePaymentAddress())
+	shardBlockBeaconHeight := shardViewRetriever.GetBeaconHeight()
+	keySet, err := wallet.Base58CheckDeserialize(chainRetriever.GetCentralizedWebsitePaymentAddress(shardBlockBeaconHeight))
 	if err != nil || !bytes.Equal(tx.GetSigPubKey(), keySet.KeySet.PaymentAddress.Pk) {
 		return false, NewMetadataTxError(IssuingRequestValidateTxWithBlockChainError, errors.New("the issuance request must be called by centralized website"))
 	}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -55,7 +55,7 @@ type MempoolRetriever interface {
 
 type ChainRetriever interface {
 	GetStakingAmountShard() uint64
-	GetCentralizedWebsitePaymentAddress() string
+	GetCentralizedWebsitePaymentAddress(uint64) string
 	GetBeaconHeightBreakPointBurnAddr() uint64
 	GetBurningAddress(blockHeight uint64) string
 	GetTransactionByHash(common.Hash) (byte, common.Hash, int, Transaction, error)
@@ -77,6 +77,7 @@ type BeaconViewRetriever interface {
 }
 
 type ShardViewRetriever interface {
+	GetBeaconHeight() uint64
 	GetStakingTx() map[string]string
 	ListShardPrivacyTokenAndPRV() []common.Hash
 	GetShardRewardStateDB() *statedb.StateDB


### PR DESCRIPTION
Should get beacon height of current shard state, instead of beacon state.