### PR TITLE
Optimize pdex init & insert

### DIFF
--- a/blockchain/beaconbeststate.go
+++ b/blockchain/beaconbeststate.go
@@ -77,6 +77,8 @@ type BeaconBestState struct {
 	FeatureStateDBRootHash   common.Hash
 	slashStateDB             *statedb.StateDB
 	SlashStateDBRootHash     common.Hash
+
+	pdeState *CurrentPDEState
 }
 
 func (beaconBestState *BeaconBestState) GetBeaconSlashStateDB() *statedb.StateDB {
@@ -447,6 +449,10 @@ func (beaconBestState *BeaconBestState) cloneBeaconBestStateFrom(target *BeaconB
 	beaconBestState.slashStateDB = target.slashStateDB.Copy()
 	beaconBestState.beaconCommitteeEngine = target.beaconCommitteeEngine.Clone()
 	beaconBestState.missingSignatureCounter = target.missingSignatureCounter.Copy()
+	if target.pdeState != nil {
+		beaconBestState.pdeState = target.pdeState.Copy()
+	}
+
 	return nil
 }
 

--- a/blockchain/beaconpdeprocess.go
+++ b/blockchain/beaconpdeprocess.go
@@ -20,7 +20,6 @@ func (blockchain *BlockChain) processPDEInstructions(beaconView *BeaconBestState
 	beaconHeight := beaconBlock.Header.Height - 1
 	currentPDEState, err := InitCurrentPDEStateFromDB(beaconView.featureStateDB, beaconView.pdeState, beaconHeight)
 	if err != nil {
-		Logger.log.Error(err)
 		return nil, err
 	}
 
@@ -46,7 +45,6 @@ func (blockchain *BlockChain) processPDEInstructions(beaconView *BeaconBestState
 			err = blockchain.processPDETradingFeesDistribution(pdexStateDB, beaconHeight, inst, currentPDEState)
 		}
 		if err != nil {
-			Logger.log.Error(err)
 			return nil, err
 		}
 	}

--- a/blockchain/beaconpdeprocess.go
+++ b/blockchain/beaconpdeprocess.go
@@ -13,12 +13,18 @@ import (
 	"github.com/incognitochain/incognito-chain/metadata"
 )
 
-func (blockchain *BlockChain) processPDEInstructions(pdexStateDB *statedb.StateDB, beaconBlock *types.BeaconBlock) error {
+func (blockchain *BlockChain) processPDEInstructions(beaconView *BeaconBestState, beaconBlock *types.BeaconBlock) error {
 	if !hasPDEInstruction(beaconBlock.Body.Instructions) {
 		return nil
 	}
+	var err error
+	pdexStateDB := beaconView.featureStateDB
 	beaconHeight := beaconBlock.Header.Height - 1
-	currentPDEState, err := InitCurrentPDEStateFromDB(pdexStateDB, beaconHeight)
+	currentPDEState := beaconView.pdeState
+	if currentPDEState == nil {
+		currentPDEState, err = InitCurrentPDEStateFromDB(beaconView.featureStateDB, beaconView.pdeState, beaconHeight)
+	}
+
 	if err != nil {
 		Logger.log.Error(err)
 		return nil

--- a/blockchain/beaconpdeprocess.go
+++ b/blockchain/beaconpdeprocess.go
@@ -14,7 +14,7 @@ import (
 
 func (blockchain *BlockChain) processPDEInstructions(beaconView *BeaconBestState, beaconBlock *types.BeaconBlock) (*CurrentPDEState, error) {
 	if !hasPDEInstruction(beaconBlock.Body.Instructions) {
-		return nil, nil
+		return beaconView.pdeState, nil
 	}
 	pdexStateDB := beaconView.featureStateDB
 	beaconHeight := beaconBlock.Header.Height - 1
@@ -53,7 +53,15 @@ func (blockchain *BlockChain) processPDEInstructions(beaconView *BeaconBestState
 	return currentPDEState, nil
 }
 
-func getDiffPDEState(previous *CurrentPDEState, current *CurrentPDEState) (diffState CurrentPDEState) {
+func getDiffPDEState(previous *CurrentPDEState, current *CurrentPDEState) (diffState *CurrentPDEState) {
+	if current == nil {
+		return nil
+	}
+	if previous == nil {
+		return current
+	}
+
+	diffState = new(CurrentPDEState)
 	diffState.WaitingPDEContributions = make(map[string]*rawdbv2.PDEContribution)
 	diffState.DeletedWaitingPDEContributions = make(map[string]*rawdbv2.PDEContribution)
 	diffState.PDEPoolPairs = make(map[string]*rawdbv2.PDEPoolForPair)

--- a/blockchain/beaconprocess.go
+++ b/blockchain/beaconprocess.go
@@ -824,6 +824,10 @@ func (blockchain *BlockChain) processStoreBeaconBlock(
 	}
 	// execute, store PDE instruction
 	newBestState.pdeState, err = blockchain.processPDEInstructions(newBestState, beaconBlock)
+	if err != nil {
+		Logger.log.Error(err)
+		return err
+	}
 	if newBestState.pdeState != nil {
 		if !reflect.DeepEqual(curView.pdeState, newBestState.pdeState) {
 			//check updated field in currentPDEState and store these field into statedb
@@ -831,6 +835,7 @@ func (blockchain *BlockChain) processStoreBeaconBlock(
 			err = storePDEStateToDB(newBestState.featureStateDB, diffState)
 			if err != nil {
 				Logger.log.Error(err)
+				return err
 			}
 		}
 		//for legacy logic prefix-currentbeaconheight-tokenid1-tokenid2

--- a/blockchain/beaconprocess.go
+++ b/blockchain/beaconprocess.go
@@ -822,7 +822,7 @@ func (blockchain *BlockChain) processStoreBeaconBlock(
 		return NewBlockChainError(ProcessBridgeInstructionError, err)
 	}
 	// execute, store PDE instruction
-	err = blockchain.processPDEInstructions(newBestState.featureStateDB, beaconBlock)
+	err = blockchain.processPDEInstructions(newBestState, beaconBlock)
 	if err != nil {
 		return NewBlockChainError(ProcessPDEInstructionError, err)
 	}

--- a/blockchain/beaconstatefulinsts.go
+++ b/blockchain/beaconstatefulinsts.go
@@ -100,7 +100,8 @@ func (blockchain *BlockChain) buildStatefulInstructions(
 	beaconHeight uint64,
 	rewardForCustodianByEpoch map[common.Hash]uint64,
 	portalParams portal.PortalParams) [][]string {
-	currentPDEState, err := InitCurrentPDEStateFromDB(featureStateDB, beaconHeight-1)
+
+	currentPDEState, err := InitCurrentPDEStateFromDB(featureStateDB, beaconBestState.pdeState, beaconHeight-1)
 	if err != nil {
 		Logger.log.Error(err)
 	}
@@ -598,4 +599,3 @@ func (blockchain *BlockChain) handlePDEInsts(
 	}
 	return instructions, nil
 }
-

--- a/blockchain/pdeutils.go
+++ b/blockchain/pdeutils.go
@@ -83,24 +83,23 @@ func InitCurrentPDEStateFromDB(
 
 func storePDEStateToDB(
 	stateDB *statedb.StateDB,
-	beaconHeight uint64,
 	currentPDEState *CurrentPDEState,
 ) error {
 	var err error
 	statedb.DeleteWaitingPDEContributions(stateDB, currentPDEState.DeletedWaitingPDEContributions)
-	err = statedb.StoreWaitingPDEContributions(stateDB, beaconHeight, currentPDEState.WaitingPDEContributions)
+	err = statedb.StoreWaitingPDEContributions(stateDB, currentPDEState.WaitingPDEContributions)
 	if err != nil {
 		return err
 	}
-	err = statedb.StorePDEPoolPairs(stateDB, beaconHeight, currentPDEState.PDEPoolPairs)
+	err = statedb.StorePDEPoolPairs(stateDB, currentPDEState.PDEPoolPairs)
 	if err != nil {
 		return err
 	}
-	err = statedb.StorePDEShares(stateDB, beaconHeight, currentPDEState.PDEShares)
+	err = statedb.StorePDEShares(stateDB, currentPDEState.PDEShares)
 	if err != nil {
 		return err
 	}
-	err = statedb.StorePDETradingFees(stateDB, beaconHeight, currentPDEState.PDETradingFees)
+	err = statedb.StorePDETradingFees(stateDB, currentPDEState.PDETradingFees)
 	if err != nil {
 		return err
 	}

--- a/blockchain/pdeutils.go
+++ b/blockchain/pdeutils.go
@@ -95,7 +95,7 @@ func (lastState *CurrentPDEState) transformKeyWithNewBeaconHeight(beaconHeight u
 	for k, v := range lastState.PDETradingFees {
 		newState.PDETradingFees[transformKey(k, beaconHeight)] = v
 	}
-	fmt.Println("transform key", time.Since(time1).Seconds())
+	Logger.log.Infof("Time spent for transforming keys: %f", time.Since(time1).Seconds())
 	return newState
 }
 
@@ -105,8 +105,8 @@ func InitCurrentPDEStateFromDB(
 	beaconHeight uint64,
 ) (*CurrentPDEState, error) {
 	if lastState != nil {
-		lastState.transformKeyWithNewBeaconHeight(beaconHeight)
-		return lastState, nil
+		newState := lastState.transformKeyWithNewBeaconHeight(beaconHeight)
+		return newState, nil
 	}
 	waitingPDEContributions, err := statedb.GetWaitingPDEContributions(stateDB, beaconHeight)
 	if err != nil {

--- a/blockchain/shardprocess.go
+++ b/blockchain/shardprocess.go
@@ -187,7 +187,7 @@ func (blockchain *BlockChain) InsertShardBlock(shardBlock *types.ShardBlock, sho
 
 	if shouldValidate {
 		// Verify block with previous best state
-		Logger.log.Debugf("SHARD %+v | Verify BestState With Shard Block, block height %+v with hash %+v", shardBlock.Header.ShardID, shardBlock.Header.Height, blockHash)
+		Logger.log.Infof("SHARD %+v | Verify BestState With Shard Block, block height %+v with hash %+v", shardBlock.Header.ShardID, shardBlock.Header.Height, blockHash)
 		if err := curView.verifyBestStateWithShardBlock(blockchain, shardBlock, committees); err != nil {
 			return err
 		}

--- a/dataaccessobject/statedb/accessor_pde.go
+++ b/dataaccessobject/statedb/accessor_pde.go
@@ -9,7 +9,7 @@ import (
 	"github.com/incognitochain/incognito-chain/dataaccessobject/rawdbv2"
 )
 
-func StoreWaitingPDEContributions(stateDB *StateDB, beaconHeight uint64, waitingPDEContributions map[string]*rawdbv2.PDEContribution) error {
+func StoreWaitingPDEContributions(stateDB *StateDB, waitingPDEContributions map[string]*rawdbv2.PDEContribution) error {
 	for tempKey, contribution := range waitingPDEContributions {
 		strs := strings.Split(tempKey, "-")
 		pairID := strings.Join(strs[2:], "-")
@@ -43,7 +43,7 @@ func DeleteWaitingPDEContributions(stateDB *StateDB, deletedWaitingPDEContributi
 	}
 }
 
-func StorePDEPoolPairs(stateDB *StateDB, beaconHeight uint64, pdePoolPairs map[string]*rawdbv2.PDEPoolForPair) error {
+func StorePDEPoolPairs(stateDB *StateDB, pdePoolPairs map[string]*rawdbv2.PDEPoolForPair) error {
 	for _, pdePoolPair := range pdePoolPairs {
 		key := GeneratePDEPoolPairObjectKey(pdePoolPair.Token1IDStr, pdePoolPair.Token2IDStr)
 		value := NewPDEPoolPairStateWithValue(pdePoolPair.Token1IDStr, pdePoolPair.Token1PoolValue, pdePoolPair.Token2IDStr, pdePoolPair.Token2PoolValue)
@@ -66,7 +66,7 @@ func GetPDEPoolPair(stateDB *StateDB, beaconHeight uint64) (map[string]*rawdbv2.
 	return pdePoolPairs, nil
 }
 
-func StorePDEShares(stateDB *StateDB, beaconHeight uint64, pdeShares map[string]uint64) error {
+func StorePDEShares(stateDB *StateDB, pdeShares map[string]uint64) error {
 	for tempKey, shareAmount := range pdeShares {
 		strs := strings.Split(tempKey, "-")
 		token1ID := strs[2]
@@ -82,7 +82,7 @@ func StorePDEShares(stateDB *StateDB, beaconHeight uint64, pdeShares map[string]
 	return nil
 }
 
-func StorePDETradingFees(stateDB *StateDB, beaconHeight uint64, pdeTradingFees map[string]uint64) error {
+func StorePDETradingFees(stateDB *StateDB, pdeTradingFees map[string]uint64) error {
 	for tempKey, feeAmount := range pdeTradingFees {
 		strs := strings.Split(tempKey, "-")
 		token1ID := strs[2]

--- a/rpcserver/http_pde.go
+++ b/rpcserver/http_pde.go
@@ -521,7 +521,7 @@ func (httpServer *HttpServer) handleGetPDEState(params interface{}, closeChan <-
 	if err != nil {
 		return nil, rpcservice.NewRPCError(rpcservice.GetPDEStateError, err)
 	}
-	pdeState, err := blockchain.InitCurrentPDEStateFromDB(beaconFeatureStateDB, uint64(beaconHeight))
+	pdeState, err := blockchain.InitCurrentPDEStateFromDB(beaconFeatureStateDB, nil, uint64(beaconHeight))
 	if err != nil {
 		return nil, rpcservice.NewRPCError(rpcservice.GetPDEStateError, err)
 	}
@@ -1063,7 +1063,7 @@ func (httpServer *HttpServer) handleConvertPDEPrices(params interface{}, closeCh
 	if err != nil {
 		return nil, rpcservice.NewRPCError(rpcservice.GetPDEStateError, err)
 	}
-	pdeState, err := blockchain.InitCurrentPDEStateFromDB(beaconFeatureStateDB, latestBeaconHeight)
+	pdeState, err := blockchain.InitCurrentPDEStateFromDB(beaconFeatureStateDB, nil, latestBeaconHeight)
 	if err != nil || pdeState == nil {
 		return nil, rpcservice.NewRPCError(rpcservice.GetPDEStateError, err)
 	}


### PR DESCRIPTION
- Store only change keypair
- Instead of initiating pdex from DB, store the current state in beacon view, and then reuse it (still keep the legacy logic of using beaconheight in key prefix)