### PR TITLE
Remove unnecessary validation rules for shield processes

### DIFF
--- a/metadata/issuingethrequest.go
+++ b/metadata/issuingethrequest.go
@@ -127,19 +127,6 @@ func (iReq IssuingETHRequest) ValidateTxWithBlockChain(tx Transaction, chainRetr
 	if ethReceipt == nil {
 		return false, errors.Errorf("The eth proof's receipt could not be null.")
 	}
-
-	// check this is a normal pToken
-	if statedb.PrivacyTokenIDExisted(transactionStateDB, iReq.IncTokenID) {
-		isBridgeToken, err := statedb.IsBridgeTokenExistedByType(beaconViewRetriever.GetBeaconFeatureStateDB(), iReq.IncTokenID, false)
-		if !isBridgeToken {
-			if err != nil {
-				return false, NewMetadataTxError(InvalidMeta, err)
-			} else {
-				return false, NewMetadataTxError(InvalidMeta, errors.New("token is invalid"))
-			}
-		}
-	}
-
 	return true, nil
 }
 

--- a/metadata/issuingrequest.go
+++ b/metadata/issuingrequest.go
@@ -139,18 +139,6 @@ func (iReq IssuingRequest) ValidateTxWithBlockChain(tx Transaction, chainRetriev
 	if err != nil || !bytes.Equal(tx.GetSigPubKey(), keySet.KeySet.PaymentAddress.Pk) {
 		return false, NewMetadataTxError(IssuingRequestValidateTxWithBlockChainError, errors.New("the issuance request must be called by centralized website"))
 	}
-
-	// check this is a normal pToken
-	if statedb.PrivacyTokenIDExisted(transactionStateDB, iReq.TokenID) {
-		isBridgeToken, err := statedb.IsBridgeTokenExistedByType(beaconViewRetriever.GetBeaconFeatureStateDB(), iReq.TokenID, true)
-		if !isBridgeToken {
-			if err != nil {
-				return false, NewMetadataTxError(InvalidMeta, err)
-			} else {
-				return false, NewMetadataTxError(InvalidMeta, errors.New("token is invalid"))
-			}
-		}
-	}
 	return true, nil
 }
 


### PR DESCRIPTION
The PR is about to fix a race condition issue between trusted and trustless bridge on shields with the same token id (yes, allowing a client to input token id to shield metadata was a design debt). The issue might cause an inconsistency between block creation and block syncing processes. For example, a transaction for requesting an issuance on a trusted bridge might bypass validation at a shard but get rejected at beacon due to another shield with trustless bridge for the same token id. Unfortunately, when a node syncs the transaction, it would not bypass the “ValidateTxWithBlockChain” validation. That’s why we need to remove the unnecessary validation rules as it is verified strictly at beacon.