### PR TITLE
move shared code to common

### DIFF
--- a/metadata/common/accumulatedvalues.go
+++ b/metadata/common/accumulatedvalues.go
@@ -1,4 +1,4 @@
-package metadata
+package common
 
 import (
 	"bytes"

--- a/metadata/common/constants.go
+++ b/metadata/common/constants.go
@@ -1,4 +1,8 @@
-package metadata
+package common
+
+import(
+	"strconv"
+)
 
 const (
 	InvalidMeta = 1
@@ -232,4 +236,14 @@ var portalMetaTypesV3 = []int{
 var portalRelayingMetaTypes = []int{
 	RelayingBNBHeaderMeta,
 	RelayingBTCHeaderMeta,
+}
+
+var bridgeMetas = []string{
+	strconv.Itoa(BeaconSwapConfirmMeta),
+	strconv.Itoa(BridgeSwapConfirmMeta),
+	strconv.Itoa(BurningConfirmMeta),
+	strconv.Itoa(BurningConfirmForDepositToSCMeta),
+	strconv.Itoa(BurningConfirmMetaV2),
+	strconv.Itoa(BurningConfirmForDepositToSCMetaV2),
+	strconv.Itoa(BurningBSCConfirmMeta),
 }

--- a/metadata/common/error.go
+++ b/metadata/common/error.go
@@ -1,4 +1,4 @@
-package metadata
+package common
 
 import (
 	"fmt"

--- a/metadata/common/log.go
+++ b/metadata/common/log.go
@@ -1,13 +1,13 @@
-package metadata
+package common
 
 import "github.com/incognitochain/incognito-chain/common"
 
 type MetaDataLogger struct {
-	log common.Logger
+	Log common.Logger
 }
 
 func (metricLogger *MetaDataLogger) Init(inst common.Logger) {
-	metricLogger.log = inst
+	metricLogger.Log = inst
 }
 
 // Global instant to use

--- a/metadata/common/metadata.go
+++ b/metadata/common/metadata.go
@@ -1,4 +1,4 @@
-package metadata
+package common
 
 import (
 	"encoding/json"

--- a/metadata/common/metadatabase.go
+++ b/metadata/common/metadatabase.go
@@ -1,4 +1,4 @@
-package metadata
+package common
 
 import (
 	"bytes"
@@ -71,20 +71,20 @@ func (mbs *MetadataBaseWithSignature) VerifyMetadataSignature(publicKey []byte, 
 			sigPubKey := tx.GetSigPubKey()
 			return bytes.Equal(sigPubKey, publicKey), nil
 		} else {
-			Logger.log.Error("CheckAuthorizedSender: should have sig for metadata to verify")
+			Logger.Log.Error("CheckAuthorizedSender: should have sig for metadata to verify")
 			return false, errors.New("CheckAuthorizedSender should have sig for metadata to verify")
 		}
 	}
 	verifyKey := new(privacy.SchnorrPublicKey)
 	metaSigPublicKey, err := new(privacy.Point).FromBytesS(publicKey)
 	if err != nil {
-		Logger.log.Error(err)
+		Logger.Log.Error(err)
 		return false, err
 	}
 	verifyKey.Set(metaSigPublicKey)
 	signature := new(privacy.SchnSignature)
 	if err := signature.SetBytes(mbs.Sig); err != nil {
-		Logger.log.Errorf("Invalid signature %v", err)
+		Logger.Log.Errorf("Invalid signature %v", err)
 		return false, err
 	}
 	return verifyKey.Verify(signature, hashForMd[:]), nil

--- a/metadata/common/utils.go
+++ b/metadata/common/utils.go
@@ -1,204 +1,15 @@
-package metadata
+package common
 
 import (
-	"encoding/json"
 	"fmt"
+	"strconv"
+
 	ec "github.com/ethereum/go-ethereum/common"
 	"github.com/incognitochain/incognito-chain/common"
 	"github.com/incognitochain/incognito-chain/privacy"
 	"github.com/incognitochain/incognito-chain/wallet"
-	"strconv"
-
 	"github.com/pkg/errors"
 )
-
-func calculateSize(meta Metadata) uint64 {
-	metaBytes, err := json.Marshal(meta)
-	if err != nil {
-		return 0
-	}
-	return uint64(len(metaBytes))
-}
-
-func ParseMetadata(meta interface{}) (Metadata, error) {
-
-	if meta == nil {
-		return nil, nil
-	}
-
-	mtTemp := map[string]interface{}{}
-	metaInBytes, err := json.Marshal(meta)
-	if err != nil {
-		return nil, err
-	}
-	err = json.Unmarshal(metaInBytes, &mtTemp)
-	if err != nil {
-		return nil, err
-	}
-
-	var md Metadata
-	typeFloat,ok := mtTemp["Type"].(float64)
-	if !ok{
-		return nil, errors.Errorf("Could not parse metadata with type: %v", mtTemp["Type"])
-	}
-	theType := int(typeFloat)
-	switch theType {
-	case InitTokenRequestMeta:
-		md = &InitTokenRequest{}
-	case InitTokenResponseMeta:
-		md = &InitTokenResponse{}
-	case IssuingRequestMeta:
-		md = &IssuingRequest{}
-	case IssuingResponseMeta:
-		md = &IssuingResponse{}
-	case ContractingRequestMeta:
-		md = &ContractingRequest{}
-	case IssuingETHRequestMeta:
-		md = &IssuingEVMRequest{}
-	case IssuingBSCRequestMeta:
-		md = &IssuingEVMRequest{}
-	case IssuingETHResponseMeta:
-		md = &IssuingEVMResponse{}
-	case IssuingBSCResponseMeta:
-		md = &IssuingEVMResponse{}
-	case BeaconSalaryResponseMeta:
-		md = &BeaconBlockSalaryRes{}
-	case BurningRequestMeta:
-		md = &BurningRequest{}
-	case BurningRequestMetaV2:
-		md = &BurningRequest{}
-	case BurningPBSCRequestMeta:
-		md = &BurningRequest{}
-	case ShardStakingMeta:
-		md = &StakingMetadata{}
-	case BeaconStakingMeta:
-		md = &StakingMetadata{}
-	case ReturnStakingMeta:
-		md = &ReturnStakingMetadata{}
-	case WithDrawRewardRequestMeta:
-		md = &WithDrawRewardRequest{}
-	case WithDrawRewardResponseMeta:
-		md = &WithDrawRewardResponse{}
-	case UnStakingMeta:
-		md = &UnStakingMetadata{}
-	case StopAutoStakingMeta:
-		md = &StopAutoStakingMetadata{}
-	case PDEContributionMeta:
-		md = &PDEContribution{}
-	case PDEPRVRequiredContributionRequestMeta:
-		md = &PDEContribution{}
-	case PDETradeRequestMeta:
-		md = &PDETradeRequest{}
-	case PDETradeResponseMeta:
-		md = &PDETradeResponse{}
-	case PDECrossPoolTradeRequestMeta:
-		md = &PDECrossPoolTradeRequest{}
-	case PDECrossPoolTradeResponseMeta:
-		md = &PDECrossPoolTradeResponse{}
-	case PDEWithdrawalRequestMeta:
-		md = &PDEWithdrawalRequest{}
-	case PDEWithdrawalResponseMeta:
-		md = &PDEWithdrawalResponse{}
-	case PDEFeeWithdrawalRequestMeta:
-		md = &PDEFeeWithdrawalRequest{}
-	case PDEFeeWithdrawalResponseMeta:
-		md = &PDEFeeWithdrawalResponse{}
-	case PDEContributionResponseMeta:
-		md = &PDEContributionResponse{}
-	case PortalCustodianDepositMeta:
-		md = &PortalCustodianDeposit{}
-	case PortalRequestPortingMeta, PortalRequestPortingMetaV3:
-		md = &PortalUserRegister{}
-	case PortalUserRequestPTokenMeta:
-		md = &PortalRequestPTokens{}
-	case PortalCustodianDepositResponseMeta:
-		md = &PortalCustodianDepositResponse{}
-	case PortalUserRequestPTokenResponseMeta:
-		md = &PortalRequestPTokensResponse{}
-	case PortalRedeemRequestMeta, PortalRedeemRequestMetaV3:
-		md = &PortalRedeemRequestV3{}
-	case PortalRedeemRequestResponseMeta:
-		md = &PortalRedeemRequestResponse{}
-	case PortalRequestUnlockCollateralMeta, PortalRequestUnlockCollateralMetaV3:
-		md = &PortalRequestUnlockCollateral{}
-	case PortalExchangeRatesMeta:
-		md = &PortalExchangeRates{}
-	case PortalUnlockOverRateCollateralsMeta:
-		md = &PortalUnlockOverRateCollaterals{}
-	case RelayingBNBHeaderMeta:
-		md = &RelayingHeader{}
-	case RelayingBTCHeaderMeta:
-		md = &RelayingHeader{}
-	case PortalCustodianWithdrawRequestMeta:
-		md = &PortalCustodianWithdrawRequest{}
-	case PortalCustodianWithdrawResponseMeta:
-		md = &PortalCustodianWithdrawResponse{}
-	case PortalLiquidateCustodianMeta, PortalLiquidateCustodianMetaV3:
-		md = &PortalLiquidateCustodian{}
-	case PortalLiquidateCustodianResponseMeta:
-		md = &PortalLiquidateCustodianResponse{}
-	case PortalRequestWithdrawRewardMeta:
-		md = &PortalRequestWithdrawReward{}
-	case PortalRequestWithdrawRewardResponseMeta:
-		md = &PortalWithdrawRewardResponse{}
-	case PortalRedeemFromLiquidationPoolMeta:
-		md = &PortalRedeemLiquidateExchangeRates{}
-	case PortalRedeemFromLiquidationPoolResponseMeta:
-		md = &PortalRedeemLiquidateExchangeRatesResponse{}
-	case PortalCustodianTopupMetaV2:
-		md = &PortalLiquidationCustodianDepositV2{}
-	case PortalCustodianTopupResponseMetaV2:
-		md = &PortalLiquidationCustodianDepositResponseV2{}
-	case PortalCustodianTopupMeta:
-		md = &PortalLiquidationCustodianDeposit{}
-	case PortalCustodianTopupResponseMeta:
-		md = &PortalLiquidationCustodianDepositResponse{}
-	case BurningForDepositToSCRequestMeta:
-		md = &BurningRequest{}
-	case BurningForDepositToSCRequestMetaV2:
-		md = &BurningRequest{}
-	case PortalPortingResponseMeta:
-		md = &PortalFeeRefundResponse{}
-	case PortalReqMatchingRedeemMeta:
-		md = &PortalReqMatchingRedeem{}
-	case PortalTopUpWaitingPortingRequestMeta:
-		md = &PortalTopUpWaitingPortingRequest{}
-	case PortalTopUpWaitingPortingResponseMeta:
-		md = &PortalTopUpWaitingPortingResponse{}
-	case PortalCustodianDepositMetaV3:
-		md = &PortalCustodianDepositV3{}
-	case PortalCustodianWithdrawRequestMetaV3:
-		md = &PortalCustodianWithdrawRequestV3{}
-	case PortalRedeemFromLiquidationPoolMetaV3:
-		md = &PortalRedeemFromLiquidationPoolV3{}
-	case PortalRedeemFromLiquidationPoolResponseMetaV3:
-		md = &PortalRedeemFromLiquidationPoolResponseV3{}
-	case PortalCustodianTopupMetaV3:
-		md = &PortalLiquidationCustodianDepositV3{}
-	case PortalTopUpWaitingPortingRequestMetaV3:
-		md = &PortalTopUpWaitingPortingRequestV3{}
-	default:
-		Logger.log.Debug("[db] parse meta err: %+v\n", meta)
-		return nil, errors.Errorf("Could not parse metadata with type: %d", theType)
-	}
-
-	err = json.Unmarshal(metaInBytes, &md)
-	if err != nil {
-		return nil, err
-	}
-	
-	return md, nil
-}
-
-var bridgeMetas = []string{
-	strconv.Itoa(BeaconSwapConfirmMeta),
-	strconv.Itoa(BridgeSwapConfirmMeta),
-	strconv.Itoa(BurningConfirmMeta),
-	strconv.Itoa(BurningConfirmForDepositToSCMeta),
-	strconv.Itoa(BurningConfirmMetaV2),
-	strconv.Itoa(BurningConfirmForDepositToSCMetaV2),
-	strconv.Itoa(BurningBSCConfirmMeta),
-}
 
 func HasBridgeInstructions(instructions [][]string) bool {
 	for _, inst := range instructions {
@@ -677,6 +488,6 @@ func GenTokenIDFromRequest(txHash string, shardID byte) *common.Hash {
 }
 
 type OTADeclaration struct {
-	PublicKey 	[32]byte
-	TokenID 	common.Hash
+	PublicKey [32]byte
+	TokenID   common.Hash
 }

--- a/metadata/exports.go
+++ b/metadata/exports.go
@@ -1,0 +1,236 @@
+package metadata
+
+import (
+	"github.com/incognitochain/incognito-chain/common"
+	metadataCommon "github.com/incognitochain/incognito-chain/metadata/common"
+)
+
+// export interfaces
+type Metadata = metadataCommon.Metadata
+type MetadataBase = metadataCommon.MetadataBase
+type MetadataBaseWithSignature = metadataCommon.MetadataBaseWithSignature
+type Transaction = metadataCommon.Transaction
+type ChainRetriever = metadataCommon.ChainRetriever
+type ShardViewRetriever = metadataCommon.ShardViewRetriever
+type BeaconViewRetriever = metadataCommon.BeaconViewRetriever
+type MempoolRetriever = metadataCommon.MempoolRetriever
+type ValidationEnviroment = metadataCommon.ValidationEnviroment
+type TxDesc = metadataCommon.TxDesc
+
+// export structs
+type OTADeclaration = metadataCommon.OTADeclaration
+type MintData = metadataCommon.MintData
+type AccumulatedValues = metadataCommon.AccumulatedValues
+
+// export package variable
+var Logger = struct {
+	log common.Logger
+	*metadataCommon.MetaDataLogger
+}{log: metadataCommon.Logger.Log, MetaDataLogger: &metadataCommon.Logger}
+var AcceptedWithdrawRewardRequestVersion = metadataCommon.AcceptedWithdrawRewardRequestVersion
+
+// export functions
+var AssertPaymentAddressAndTxVersion = metadataCommon.AssertPaymentAddressAndTxVersion
+var GenTokenIDFromRequest = metadataCommon.GenTokenIDFromRequest
+var NewMetadataBase = metadataCommon.NewMetadataBase
+var NewMetadataBaseWithSignature = metadataCommon.NewMetadataBaseWithSignature
+var ValidatePortalExternalAddress = metadataCommon.ValidatePortalExternalAddress
+var NewMetadataTxError = metadataCommon.NewMetadataTxError
+var IsAvailableMetaInTxType = metadataCommon.IsAvailableMetaInTxType
+var NoInputNoOutput = metadataCommon.NoInputNoOutput
+var NoInputHasOutput = metadataCommon.NoInputHasOutput
+var IsPortalRelayingMetaType = metadataCommon.IsPortalRelayingMetaType
+var IsPortalMetaTypeV3 = metadataCommon.IsPortalMetaTypeV3
+var GetMetaAction = metadataCommon.GetMetaAction
+var IsPDEType = metadataCommon.IsPDEType
+var IspDEXv3Type = metadataCommon.IspDEXv3Type
+var GetLimitOfMeta = metadataCommon.GetLimitOfMeta
+var IsPDETx = metadataCommon.IsPDETx
+var ConvertPrivacyTokenToNativeToken = metadataCommon.ConvertPrivacyTokenToNativeToken
+var ConvertNativeTokenToPrivacyToken = metadataCommon.ConvertNativeTokenToPrivacyToken
+var HasBridgeInstructions = metadataCommon.HasBridgeInstructions
+var HasPortalInstructions = metadataCommon.HasPortalInstructions
+
+// export package constants
+const (
+	InvalidMeta                  = metadataCommon.InvalidMeta
+	IssuingRequestMeta           = metadataCommon.IssuingRequestMeta
+	IssuingResponseMeta          = metadataCommon.IssuingResponseMeta
+	ContractingRequestMeta       = metadataCommon.ContractingRequestMeta
+	IssuingETHRequestMeta        = metadataCommon.IssuingETHRequestMeta
+	IssuingETHResponseMeta       = metadataCommon.IssuingETHResponseMeta
+	ShardBlockReward             = metadataCommon.ShardBlockReward
+	AcceptedBlockRewardInfoMeta  = metadataCommon.AcceptedBlockRewardInfoMeta
+	ShardBlockSalaryResponseMeta = metadataCommon.ShardBlockSalaryResponseMeta
+	BeaconRewardRequestMeta      = metadataCommon.BeaconRewardRequestMeta
+	BeaconSalaryResponseMeta     = metadataCommon.BeaconSalaryResponseMeta
+	ReturnStakingMeta            = metadataCommon.ReturnStakingMeta
+	IncDAORewardRequestMeta      = metadataCommon.IncDAORewardRequestMeta
+	ShardBlockRewardRequestMeta  = metadataCommon.ShardBlockRewardRequestMeta
+	WithDrawRewardRequestMeta    = metadataCommon.WithDrawRewardRequestMeta
+	WithDrawRewardResponseMeta   = metadataCommon.WithDrawRewardResponseMeta
+	//staking
+	ShardStakingMeta    = metadataCommon.ShardStakingMeta
+	StopAutoStakingMeta = metadataCommon.StopAutoStakingMeta
+	BeaconStakingMeta   = metadataCommon.BeaconStakingMeta
+	UnStakingMeta       = metadataCommon.UnStakingMeta
+	// Incognito -> Ethereum bridge
+	BeaconSwapConfirmMeta = metadataCommon.BeaconSwapConfirmMeta
+	BridgeSwapConfirmMeta = metadataCommon.BridgeSwapConfirmMeta
+	BurningRequestMeta    = metadataCommon.BurningRequestMeta
+	BurningRequestMetaV2  = metadataCommon.BurningRequestMetaV2
+	BurningConfirmMeta    = metadataCommon.BurningConfirmMeta
+	BurningConfirmMetaV2  = metadataCommon.BurningConfirmMetaV2
+	// pde
+	PDEContributionMeta                   = metadataCommon.PDEContributionMeta
+	PDETradeRequestMeta                   = metadataCommon.PDETradeRequestMeta
+	PDETradeResponseMeta                  = metadataCommon.PDETradeResponseMeta
+	PDEWithdrawalRequestMeta              = metadataCommon.PDEWithdrawalRequestMeta
+	PDEWithdrawalResponseMeta             = metadataCommon.PDEWithdrawalResponseMeta
+	PDEContributionResponseMeta           = metadataCommon.PDEContributionResponseMeta
+	PDEPRVRequiredContributionRequestMeta = metadataCommon.PDEPRVRequiredContributionRequestMeta
+	PDECrossPoolTradeRequestMeta          = metadataCommon.PDECrossPoolTradeRequestMeta
+	PDECrossPoolTradeResponseMeta         = metadataCommon.PDECrossPoolTradeResponseMeta
+	PDEFeeWithdrawalRequestMeta           = metadataCommon.PDEFeeWithdrawalRequestMeta
+	PDEFeeWithdrawalResponseMeta          = metadataCommon.PDEFeeWithdrawalResponseMeta
+	PDETradingFeesDistributionMeta        = metadataCommon.PDETradingFeesDistributionMeta
+	// pDEX v3
+	PDexV3ModifyParamsMeta = metadataCommon.PDexV3ModifyParamsMeta
+	// portal
+	PortalCustodianDepositMeta                  = metadataCommon.PortalCustodianDepositMeta
+	PortalRequestPortingMeta                    = metadataCommon.PortalRequestPortingMeta
+	PortalUserRequestPTokenMeta                 = metadataCommon.PortalUserRequestPTokenMeta
+	PortalCustodianDepositResponseMeta          = metadataCommon.PortalCustodianDepositResponseMeta
+	PortalUserRequestPTokenResponseMeta         = metadataCommon.PortalUserRequestPTokenResponseMeta
+	PortalExchangeRatesMeta                     = metadataCommon.PortalExchangeRatesMeta
+	PortalRedeemRequestMeta                     = metadataCommon.PortalRedeemRequestMeta
+	PortalRedeemRequestResponseMeta             = metadataCommon.PortalRedeemRequestResponseMeta
+	PortalRequestUnlockCollateralMeta           = metadataCommon.PortalRequestUnlockCollateralMeta
+	PortalCustodianWithdrawRequestMeta          = metadataCommon.PortalCustodianWithdrawRequestMeta
+	PortalCustodianWithdrawResponseMeta         = metadataCommon.PortalCustodianWithdrawResponseMeta
+	PortalLiquidateCustodianMeta                = metadataCommon.PortalLiquidateCustodianMeta
+	PortalLiquidateCustodianResponseMeta        = metadataCommon.PortalLiquidateCustodianResponseMeta
+	PortalLiquidateTPExchangeRatesMeta          = metadataCommon.PortalLiquidateTPExchangeRatesMeta
+	PortalExpiredWaitingPortingReqMeta          = metadataCommon.PortalExpiredWaitingPortingReqMeta
+	PortalRewardMeta                            = metadataCommon.PortalRewardMeta
+	PortalRequestWithdrawRewardMeta             = metadataCommon.PortalRequestWithdrawRewardMeta
+	PortalRequestWithdrawRewardResponseMeta     = metadataCommon.PortalRequestWithdrawRewardResponseMeta
+	PortalRedeemFromLiquidationPoolMeta         = metadataCommon.PortalRedeemFromLiquidationPoolMeta
+	PortalRedeemFromLiquidationPoolResponseMeta = metadataCommon.PortalRedeemFromLiquidationPoolResponseMeta
+	PortalCustodianTopupMeta                    = metadataCommon.PortalCustodianTopupMeta
+	PortalCustodianTopupResponseMeta            = metadataCommon.PortalCustodianTopupResponseMeta
+	PortalTotalRewardCustodianMeta              = metadataCommon.PortalTotalRewardCustodianMeta
+	PortalPortingResponseMeta                   = metadataCommon.PortalPortingResponseMeta
+	PortalReqMatchingRedeemMeta                 = metadataCommon.PortalReqMatchingRedeemMeta
+	PortalPickMoreCustodianForRedeemMeta        = metadataCommon.PortalPickMoreCustodianForRedeemMeta
+	PortalCustodianTopupMetaV2                  = metadataCommon.PortalCustodianTopupMetaV2
+	PortalCustodianTopupResponseMetaV2          = metadataCommon.PortalCustodianTopupResponseMetaV2
+	// Portal v3
+	PortalCustodianDepositMetaV3                  = metadataCommon.PortalCustodianDepositMetaV3
+	PortalCustodianWithdrawRequestMetaV3          = metadataCommon.PortalCustodianWithdrawRequestMetaV3
+	PortalRewardMetaV3                            = metadataCommon.PortalRewardMetaV3
+	PortalRequestUnlockCollateralMetaV3           = metadataCommon.PortalRequestUnlockCollateralMetaV3
+	PortalLiquidateCustodianMetaV3                = metadataCommon.PortalLiquidateCustodianMetaV3
+	PortalLiquidateByRatesMetaV3                  = metadataCommon.PortalLiquidateByRatesMetaV3
+	PortalRedeemFromLiquidationPoolMetaV3         = metadataCommon.PortalRedeemFromLiquidationPoolMetaV3
+	PortalRedeemFromLiquidationPoolResponseMetaV3 = metadataCommon.PortalRedeemFromLiquidationPoolResponseMetaV3
+	PortalCustodianTopupMetaV3                    = metadataCommon.PortalCustodianTopupMetaV3
+	PortalTopUpWaitingPortingRequestMetaV3        = metadataCommon.PortalTopUpWaitingPortingRequestMetaV3
+	PortalRequestPortingMetaV3                    = metadataCommon.PortalRequestPortingMetaV3
+	PortalRedeemRequestMetaV3                     = metadataCommon.PortalRedeemRequestMetaV3
+	PortalUnlockOverRateCollateralsMeta           = metadataCommon.PortalUnlockOverRateCollateralsMeta
+	// Incognito => Ethereum's SC for portal
+	PortalCustodianWithdrawConfirmMetaV3         = metadataCommon.PortalCustodianWithdrawConfirmMetaV3
+	PortalRedeemFromLiquidationPoolConfirmMetaV3 = metadataCommon.PortalRedeemFromLiquidationPoolConfirmMetaV3
+	PortalLiquidateRunAwayCustodianConfirmMetaV3 = metadataCommon.PortalLiquidateRunAwayCustodianConfirmMetaV3
+	//Note: don't use this metadata type for others
+	PortalResetPortalDBMeta = metadataCommon.PortalResetPortalDBMeta
+	// relaying
+	RelayingBNBHeaderMeta                 = metadataCommon.RelayingBNBHeaderMeta
+	RelayingBTCHeaderMeta                 = metadataCommon.RelayingBTCHeaderMeta
+	PortalTopUpWaitingPortingRequestMeta  = metadataCommon.PortalTopUpWaitingPortingRequestMeta
+	PortalTopUpWaitingPortingResponseMeta = metadataCommon.PortalTopUpWaitingPortingResponseMeta
+	// incognito mode for smart contract
+	BurningForDepositToSCRequestMeta   = metadataCommon.BurningForDepositToSCRequestMeta
+	BurningForDepositToSCRequestMetaV2 = metadataCommon.BurningForDepositToSCRequestMetaV2
+	BurningConfirmForDepositToSCMeta   = metadataCommon.BurningConfirmForDepositToSCMeta
+	BurningConfirmForDepositToSCMetaV2 = metadataCommon.BurningConfirmForDepositToSCMetaV2
+	InitTokenRequestMeta               = metadataCommon.InitTokenRequestMeta
+	InitTokenResponseMeta              = metadataCommon.InitTokenResponseMeta
+	// incognito mode for bsc
+	IssuingBSCRequestMeta    = metadataCommon.IssuingBSCRequestMeta
+	IssuingBSCResponseMeta   = metadataCommon.IssuingBSCResponseMeta
+	BurningPBSCRequestMeta   = metadataCommon.BurningPBSCRequestMeta
+	BurningBSCConfirmMeta    = metadataCommon.BurningBSCConfirmMeta
+	AllShards                = metadataCommon.AllShards
+	BeaconOnly               = metadataCommon.BeaconOnly
+	StopAutoStakingAmount    = metadataCommon.StopAutoStakingAmount
+	EVMConfirmationBlocks    = metadataCommon.EVMConfirmationBlocks
+	NoAction                 = metadataCommon.NoAction
+	MetaRequestBeaconMintTxs = metadataCommon.MetaRequestBeaconMintTxs
+	MetaRequestShardMintTxs  = metadataCommon.MetaRequestShardMintTxs
+)
+
+// export error codes
+const (
+	UnexpectedError                                            = metadataCommon.UnexpectedError
+	IssuingEvmRequestDecodeInstructionError                    = metadataCommon.IssuingEvmRequestDecodeInstructionError
+	IssuingEvmRequestUnmarshalJsonError                        = metadataCommon.IssuingEvmRequestUnmarshalJsonError
+	IssuingEvmRequestNewIssuingEVMRequestFromMapError          = metadataCommon.IssuingEvmRequestNewIssuingEVMRequestFromMapError
+	IssuingEvmRequestValidateTxWithBlockChainError             = metadataCommon.IssuingEvmRequestValidateTxWithBlockChainError
+	IssuingEvmRequestValidateSanityDataError                   = metadataCommon.IssuingEvmRequestValidateSanityDataError
+	IssuingEvmRequestBuildReqActionsError                      = metadataCommon.IssuingEvmRequestBuildReqActionsError
+	IssuingEvmRequestVerifyProofAndParseReceipt                = metadataCommon.IssuingEvmRequestVerifyProofAndParseReceipt
+	IssuingRequestDecodeInstructionError                       = metadataCommon.IssuingRequestDecodeInstructionError
+	IssuingRequestUnmarshalJsonError                           = metadataCommon.IssuingRequestUnmarshalJsonError
+	IssuingRequestNewIssuingRequestFromMapEror                 = metadataCommon.IssuingRequestNewIssuingRequestFromMapEror
+	IssuingRequestValidateTxWithBlockChainError                = metadataCommon.IssuingRequestValidateTxWithBlockChainError
+	IssuingRequestValidateSanityDataError                      = metadataCommon.IssuingRequestValidateSanityDataError
+	IssuingRequestBuildReqActionsError                         = metadataCommon.IssuingRequestBuildReqActionsError
+	IssuingRequestVerifyProofAndParseReceipt                   = metadataCommon.IssuingRequestVerifyProofAndParseReceipt
+	BeaconBlockRewardNewBeaconBlockRewardInfoFromStrError      = metadataCommon.BeaconBlockRewardNewBeaconBlockRewardInfoFromStrError
+	BeaconBlockRewardBuildInstructionForBeaconBlockRewardError = metadataCommon.BeaconBlockRewardBuildInstructionForBeaconBlockRewardError
+	StopAutoStakingRequestNotInCommitteeListError              = metadataCommon.StopAutoStakingRequestNotInCommitteeListError
+	StopAutoStakingRequestGetStakingTransactionError           = metadataCommon.StopAutoStakingRequestGetStakingTransactionError
+	StopAutoStakingRequestStakingTransactionNotFoundError      = metadataCommon.StopAutoStakingRequestStakingTransactionNotFoundError
+	StopAutoStakingRequestInvalidTransactionSenderError        = metadataCommon.StopAutoStakingRequestInvalidTransactionSenderError
+	StopAutoStakingRequestNoAutoStakingAvaiableError           = metadataCommon.StopAutoStakingRequestNoAutoStakingAvaiableError
+	StopAutoStakingRequestTypeAssertionError                   = metadataCommon.StopAutoStakingRequestTypeAssertionError
+	StopAutoStakingRequestAlreadyStopError                     = metadataCommon.StopAutoStakingRequestAlreadyStopError
+	WrongIncognitoDAOPaymentAddressError                       = metadataCommon.WrongIncognitoDAOPaymentAddressError
+	// pde
+	PDEWithdrawalRequestFromMapError    = metadataCommon.PDEWithdrawalRequestFromMapError
+	CouldNotGetExchangeRateError        = metadataCommon.CouldNotGetExchangeRateError
+	RejectInvalidFee                    = metadataCommon.RejectInvalidFee
+	PDEFeeWithdrawalRequestFromMapError = metadataCommon.PDEFeeWithdrawalRequestFromMapError
+	// portal
+	PortalRequestPTokenParamError                = metadataCommon.PortalRequestPTokenParamError
+	PortalRedeemRequestParamError                = metadataCommon.PortalRedeemRequestParamError
+	PortalRedeemLiquidateExchangeRatesParamError = metadataCommon.PortalRedeemLiquidateExchangeRatesParamError
+	// Unstake
+	UnStakingRequestNotInCommitteeListError         = metadataCommon.UnStakingRequestNotInCommitteeListError
+	UnStakingRequestGetStakerInfoError              = metadataCommon.UnStakingRequestGetStakerInfoError
+	UnStakingRequestNotFoundStakerInfoError         = metadataCommon.UnStakingRequestNotFoundStakerInfoError
+	UnStakingRequestStakingTransactionNotFoundError = metadataCommon.UnStakingRequestStakingTransactionNotFoundError
+	UnStakingRequestInvalidTransactionSenderError   = metadataCommon.UnStakingRequestInvalidTransactionSenderError
+	UnStakingRequestNoAutoStakingAvaiableError      = metadataCommon.UnStakingRequestNoAutoStakingAvaiableError
+	UnStakingRequestTypeAssertionError              = metadataCommon.UnStakingRequestTypeAssertionError
+	UnStakingRequestAlreadyStopError                = metadataCommon.UnStakingRequestAlreadyStopError
+	UnStakingRequestInvalidFormatRequestKey         = metadataCommon.UnStakingRequestInvalidFormatRequestKey
+	UnstakingRequestAlreadyUnstake                  = metadataCommon.UnstakingRequestAlreadyUnstake
+	// eth utils
+	VerifyProofAndParseReceiptError = metadataCommon.VerifyProofAndParseReceiptError
+	// init privacy custom token
+	InitTokenRequestDecodeInstructionError           = metadataCommon.InitTokenRequestDecodeInstructionError
+	InitTokenRequestUnmarshalJsonError               = metadataCommon.InitTokenRequestUnmarshalJsonError
+	InitTokenRequestNewInitPTokenRequestFromMapError = metadataCommon.InitTokenRequestNewInitPTokenRequestFromMapError
+	InitTokenRequestValidateTxWithBlockChainError    = metadataCommon.InitTokenRequestValidateTxWithBlockChainError
+	InitTokenRequestValidateSanityDataError          = metadataCommon.InitTokenRequestValidateSanityDataError
+	InitTokenRequestBuildReqActionsError             = metadataCommon.InitTokenRequestBuildReqActionsError
+	InitTokenResponseValidateSanityDataError         = metadataCommon.InitTokenResponseValidateSanityDataError
+	// portal v3
+	PortalCustodianDepositV3ValidateWithBCError     = metadataCommon.PortalCustodianDepositV3ValidateWithBCError
+	PortalCustodianDepositV3ValidateSanityDataError = metadataCommon.PortalCustodianDepositV3ValidateSanityDataError
+	NewPortalCustodianDepositV3MetaFromMapError     = metadataCommon.NewPortalCustodianDepositV3MetaFromMapError
+	PortalUnlockOverRateCollateralsError            = metadataCommon.PortalUnlockOverRateCollateralsError
+)

--- a/metadata/parse.go
+++ b/metadata/parse.go
@@ -1,0 +1,185 @@
+package metadata
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+func calculateSize(meta Metadata) uint64 {
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return 0
+	}
+	return uint64(len(metaBytes))
+}
+
+func ParseMetadata(meta interface{}) (Metadata, error) {
+
+	if meta == nil {
+		return nil, nil
+	}
+
+	mtTemp := map[string]interface{}{}
+	metaInBytes, err := json.Marshal(meta)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(metaInBytes, &mtTemp)
+	if err != nil {
+		return nil, err
+	}
+
+	var md Metadata
+	typeFloat, ok := mtTemp["Type"].(float64)
+	if !ok {
+		return nil, errors.Errorf("Could not parse metadata with type: %v", mtTemp["Type"])
+	}
+	theType := int(typeFloat)
+	switch theType {
+	case InitTokenRequestMeta:
+		md = &InitTokenRequest{}
+	case InitTokenResponseMeta:
+		md = &InitTokenResponse{}
+	case IssuingRequestMeta:
+		md = &IssuingRequest{}
+	case IssuingResponseMeta:
+		md = &IssuingResponse{}
+	case ContractingRequestMeta:
+		md = &ContractingRequest{}
+	case IssuingETHRequestMeta:
+		md = &IssuingEVMRequest{}
+	case IssuingBSCRequestMeta:
+		md = &IssuingEVMRequest{}
+	case IssuingETHResponseMeta:
+		md = &IssuingEVMResponse{}
+	case IssuingBSCResponseMeta:
+		md = &IssuingEVMResponse{}
+	case BeaconSalaryResponseMeta:
+		md = &BeaconBlockSalaryRes{}
+	case BurningRequestMeta:
+		md = &BurningRequest{}
+	case BurningRequestMetaV2:
+		md = &BurningRequest{}
+	case BurningPBSCRequestMeta:
+		md = &BurningRequest{}
+	case ShardStakingMeta:
+		md = &StakingMetadata{}
+	case BeaconStakingMeta:
+		md = &StakingMetadata{}
+	case ReturnStakingMeta:
+		md = &ReturnStakingMetadata{}
+	case WithDrawRewardRequestMeta:
+		md = &WithDrawRewardRequest{}
+	case WithDrawRewardResponseMeta:
+		md = &WithDrawRewardResponse{}
+	case UnStakingMeta:
+		md = &UnStakingMetadata{}
+	case StopAutoStakingMeta:
+		md = &StopAutoStakingMetadata{}
+	case PDEContributionMeta:
+		md = &PDEContribution{}
+	case PDEPRVRequiredContributionRequestMeta:
+		md = &PDEContribution{}
+	case PDETradeRequestMeta:
+		md = &PDETradeRequest{}
+	case PDETradeResponseMeta:
+		md = &PDETradeResponse{}
+	case PDECrossPoolTradeRequestMeta:
+		md = &PDECrossPoolTradeRequest{}
+	case PDECrossPoolTradeResponseMeta:
+		md = &PDECrossPoolTradeResponse{}
+	case PDEWithdrawalRequestMeta:
+		md = &PDEWithdrawalRequest{}
+	case PDEWithdrawalResponseMeta:
+		md = &PDEWithdrawalResponse{}
+	case PDEFeeWithdrawalRequestMeta:
+		md = &PDEFeeWithdrawalRequest{}
+	case PDEFeeWithdrawalResponseMeta:
+		md = &PDEFeeWithdrawalResponse{}
+	case PDEContributionResponseMeta:
+		md = &PDEContributionResponse{}
+	case PortalCustodianDepositMeta:
+		md = &PortalCustodianDeposit{}
+	case PortalRequestPortingMeta, PortalRequestPortingMetaV3:
+		md = &PortalUserRegister{}
+	case PortalUserRequestPTokenMeta:
+		md = &PortalRequestPTokens{}
+	case PortalCustodianDepositResponseMeta:
+		md = &PortalCustodianDepositResponse{}
+	case PortalUserRequestPTokenResponseMeta:
+		md = &PortalRequestPTokensResponse{}
+	case PortalRedeemRequestMeta, PortalRedeemRequestMetaV3:
+		md = &PortalRedeemRequestV3{}
+	case PortalRedeemRequestResponseMeta:
+		md = &PortalRedeemRequestResponse{}
+	case PortalRequestUnlockCollateralMeta, PortalRequestUnlockCollateralMetaV3:
+		md = &PortalRequestUnlockCollateral{}
+	case PortalExchangeRatesMeta:
+		md = &PortalExchangeRates{}
+	case PortalUnlockOverRateCollateralsMeta:
+		md = &PortalUnlockOverRateCollaterals{}
+	case RelayingBNBHeaderMeta:
+		md = &RelayingHeader{}
+	case RelayingBTCHeaderMeta:
+		md = &RelayingHeader{}
+	case PortalCustodianWithdrawRequestMeta:
+		md = &PortalCustodianWithdrawRequest{}
+	case PortalCustodianWithdrawResponseMeta:
+		md = &PortalCustodianWithdrawResponse{}
+	case PortalLiquidateCustodianMeta, PortalLiquidateCustodianMetaV3:
+		md = &PortalLiquidateCustodian{}
+	case PortalLiquidateCustodianResponseMeta:
+		md = &PortalLiquidateCustodianResponse{}
+	case PortalRequestWithdrawRewardMeta:
+		md = &PortalRequestWithdrawReward{}
+	case PortalRequestWithdrawRewardResponseMeta:
+		md = &PortalWithdrawRewardResponse{}
+	case PortalRedeemFromLiquidationPoolMeta:
+		md = &PortalRedeemLiquidateExchangeRates{}
+	case PortalRedeemFromLiquidationPoolResponseMeta:
+		md = &PortalRedeemLiquidateExchangeRatesResponse{}
+	case PortalCustodianTopupMetaV2:
+		md = &PortalLiquidationCustodianDepositV2{}
+	case PortalCustodianTopupResponseMetaV2:
+		md = &PortalLiquidationCustodianDepositResponseV2{}
+	case PortalCustodianTopupMeta:
+		md = &PortalLiquidationCustodianDeposit{}
+	case PortalCustodianTopupResponseMeta:
+		md = &PortalLiquidationCustodianDepositResponse{}
+	case BurningForDepositToSCRequestMeta:
+		md = &BurningRequest{}
+	case BurningForDepositToSCRequestMetaV2:
+		md = &BurningRequest{}
+	case PortalPortingResponseMeta:
+		md = &PortalFeeRefundResponse{}
+	case PortalReqMatchingRedeemMeta:
+		md = &PortalReqMatchingRedeem{}
+	case PortalTopUpWaitingPortingRequestMeta:
+		md = &PortalTopUpWaitingPortingRequest{}
+	case PortalTopUpWaitingPortingResponseMeta:
+		md = &PortalTopUpWaitingPortingResponse{}
+	case PortalCustodianDepositMetaV3:
+		md = &PortalCustodianDepositV3{}
+	case PortalCustodianWithdrawRequestMetaV3:
+		md = &PortalCustodianWithdrawRequestV3{}
+	case PortalRedeemFromLiquidationPoolMetaV3:
+		md = &PortalRedeemFromLiquidationPoolV3{}
+	case PortalRedeemFromLiquidationPoolResponseMetaV3:
+		md = &PortalRedeemFromLiquidationPoolResponseV3{}
+	case PortalCustodianTopupMetaV3:
+		md = &PortalLiquidationCustodianDepositV3{}
+	case PortalTopUpWaitingPortingRequestMetaV3:
+		md = &PortalTopUpWaitingPortingRequestV3{}
+	default:
+		Logger.Log.Debug("[db] parse meta err: %+v\n", meta)
+		return nil, errors.Errorf("Could not parse metadata with type: %d", theType)
+	}
+
+	err = json.Unmarshal(metaInBytes, &md)
+	if err != nil {
+		return nil, err
+	}
+
+	return md, nil
+}


### PR DESCRIPTION
- keep as much current code as possible
- code that will be reused go in `common`
- re-export necessary symbols in `exports.go`
- allow new pdex-v3 metadata types to go in its own subfolder