### PR TITLE
OTA Receiver struct + Metadata for trades

### DIFF
--- a/metadata/common/constants.go
+++ b/metadata/common/constants.go
@@ -54,6 +54,12 @@ const (
 
 	// pDEX v3
 	PDexV3ModifyParamsMeta = 270
+	PDexV3TradeRequestMeta = 273
+	PDexV3TradeResponseMeta = 274
+	PDexV3AddOrderRequestMeta = 275
+	PDexV3AddOrderResponseMeta = 276
+	PDexV3WithdrawOrderRequestMeta = 277
+	PDexV3WithdrawOrderResponseMeta = 278
 
 	// portal
 	PortalCustodianDepositMeta                  = 100

--- a/metadata/common/utils.go
+++ b/metadata/common/utils.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -10,6 +11,14 @@ import (
 	"github.com/incognitochain/incognito-chain/wallet"
 	"github.com/pkg/errors"
 )
+
+func CalculateSize(meta Metadata) uint64 {
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return 0
+	}
+	return uint64(len(metaBytes))
+}
 
 func HasBridgeInstructions(instructions [][]string) bool {
 	for _, inst := range instructions {

--- a/metadata/exports.go
+++ b/metadata/exports.go
@@ -51,6 +51,8 @@ var ConvertNativeTokenToPrivacyToken = metadataCommon.ConvertNativeTokenToPrivac
 var HasBridgeInstructions = metadataCommon.HasBridgeInstructions
 var HasPortalInstructions = metadataCommon.HasPortalInstructions
 
+var calculateSize = metadataCommon.CalculateSize
+
 // export package constants
 const (
 	InvalidMeta                  = metadataCommon.InvalidMeta
@@ -96,6 +98,12 @@ const (
 	PDETradingFeesDistributionMeta        = metadataCommon.PDETradingFeesDistributionMeta
 	// pDEX v3
 	PDexV3ModifyParamsMeta = metadataCommon.PDexV3ModifyParamsMeta
+	PDexV3TradeRequestMeta = metadataCommon.PDexV3TradeRequestMeta
+	PDexV3TradeResponseMeta = metadataCommon.PDexV3TradeResponseMeta
+	PDexV3AddOrderRequestMeta = metadataCommon.PDexV3AddOrderRequestMeta
+	PDexV3AddOrderResponseMeta = metadataCommon.PDexV3AddOrderResponseMeta
+	PDexV3WithdrawOrderRequestMeta = metadataCommon.PDexV3WithdrawOrderRequestMeta
+	PDexV3WithdrawOrderResponseMeta = metadataCommon.PDexV3WithdrawOrderResponseMeta
 	// portal
 	PortalCustodianDepositMeta                  = metadataCommon.PortalCustodianDepositMeta
 	PortalRequestPortingMeta                    = metadataCommon.PortalRequestPortingMeta

--- a/metadata/parse.go
+++ b/metadata/parse.go
@@ -6,14 +6,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func calculateSize(meta Metadata) uint64 {
-	metaBytes, err := json.Marshal(meta)
-	if err != nil {
-		return 0
-	}
-	return uint64(len(metaBytes))
-}
-
 func ParseMetadata(meta interface{}) (Metadata, error) {
 
 	if meta == nil {

--- a/metadata/pdexv3/addOrder.go
+++ b/metadata/pdexv3/addOrder.go
@@ -84,25 +84,6 @@ func (req AddOrderRequest) Hash() *common.Hash {
 	return &hash
 }
 
-func (req *AddOrderRequest) BuildReqActions(tx metadataCommon.Transaction, chainRetriever metadataCommon.ChainRetriever, shardViewRetriever metadataCommon.ShardViewRetriever, beaconViewRetriever metadataCommon.BeaconViewRetriever, shardID byte, shardHeight uint64) ([][]string, error) {
-	action := AddOrderAction{
-		Metadata:    *req,
-		ShardID:     shardID,
-		RequestTxID: *tx.Hash(),
-	}
-	b, err := json.Marshal(action)
-	if err != nil {
-		return [][]string{}, err
-	}
-	actionEncoded := base64.StdEncoding.EncodeToString(b)
-	return [][]string{
-		[]string{
-			strconv.Itoa(metadataCommon.PDexV3AddOrderRequestMeta),
-			actionEncoded,
-		},
-	}, nil
-}
-
 func (req *AddOrderRequest) CalculateSize() uint64 {
 	return metadataCommon.CalculateSize(req)
 }

--- a/metadata/pdexv3/addOrder.go
+++ b/metadata/pdexv3/addOrder.go
@@ -1,0 +1,118 @@
+package metadata
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strconv"
+
+	"github.com/incognitochain/incognito-chain/common"
+	"github.com/incognitochain/incognito-chain/dataaccessobject/statedb"
+	metadataCommon "github.com/incognitochain/incognito-chain/metadata/common"
+	"github.com/incognitochain/incognito-chain/privacy"
+)
+
+// AddOrderRequest
+type AddOrderRequest struct {
+	TokenToSell         common.Hash         `json:"TokenToSell"`
+	TokenToBuy          common.Hash         `json:"TokenToBuy"`
+	SellAmount          uint64              `json:"SellAmount"`
+	MinAcceptableAmount uint64              `json:"MinAcceptableAmount"`
+	TradingFee          uint64              `json:"TradingFee"`
+	RefundReceiver      privacy.OTAReceiver `json:"RefundReceiver"`
+	metadataCommon.MetadataBase
+}
+
+type AddOrderAction struct {
+	Metadata    AddOrderRequest `json:"Metadata"`
+	ShardID     byte            `json:"ShardID"`
+	RequestTxID common.Hash     `json:"RequestTxID"`
+}
+
+type AcceptedAddOrder struct {
+	TokenToBuy  common.Hash `json:"TokenToBuy"`
+	PairID      string      `json:"PairID"`
+	ShardID     byte        `json:"ShardID"`
+	RequestTxID common.Hash `json:"RequestTxID"`
+}
+
+type RefundedAddOrder struct {
+	Receiver    privacy.OTAReceiver `json:"Receiver"`
+	TokenToSell common.Hash         `json:"TokenToSell"`
+	Amount      uint64              `json:"Amount"`
+	ShardID     byte                `json:"ShardID`
+	RequestTxID common.Hash         `json:"RequestTxID"`
+}
+
+func NewAddOrderRequest(
+	tokenToBuy common.Hash,
+	tokenToSell common.Hash,
+	sellAmount uint64,
+	minAcceptableAmount uint64,
+	tradingFee uint64,
+	refundRecv privacy.OTAReceiver,
+	metaType int,
+) (*AddOrderRequest, error) {
+	pdeTradeRequest := &AddOrderRequest{
+		TokenToSell:         tokenToSell,
+		TokenToBuy:          tokenToBuy,
+		SellAmount:          sellAmount,
+		MinAcceptableAmount: minAcceptableAmount,
+		TradingFee:          tradingFee,
+		RefundReceiver:      refundRecv,
+		MetadataBase: metadataCommon.MetadataBase{
+			Type: metaType,
+		},
+	}
+	return pdeTradeRequest, nil
+}
+
+func (req AddOrderRequest) ValidateTxWithBlockChain(tx metadataCommon.Transaction, chainRetriever metadataCommon.ChainRetriever, shardViewRetriever metadataCommon.ShardViewRetriever, beaconViewRetriever metadataCommon.BeaconViewRetriever, shardID byte, transactionStateDB *statedb.StateDB) (bool, error) {
+	return true, nil
+}
+
+func (req AddOrderRequest) ValidateSanityData(chainRetriever metadataCommon.ChainRetriever, shardViewRetriever metadataCommon.ShardViewRetriever, beaconViewRetriever metadataCommon.BeaconViewRetriever, beaconHeight uint64, tx metadataCommon.Transaction) (bool, bool, error) {
+	return true, true, nil
+}
+
+func (req AddOrderRequest) ValidateMetadataByItself() bool {
+	return req.Type == metadataCommon.PDexV3AddOrderRequestMeta
+}
+
+func (req AddOrderRequest) Hash() *common.Hash {
+	rawBytes, _ := json.Marshal(req)
+	hash := common.HashH([]byte(rawBytes))
+	return &hash
+}
+
+func (req *AddOrderRequest) BuildReqActions(tx metadataCommon.Transaction, chainRetriever metadataCommon.ChainRetriever, shardViewRetriever metadataCommon.ShardViewRetriever, beaconViewRetriever metadataCommon.BeaconViewRetriever, shardID byte, shardHeight uint64) ([][]string, error) {
+	action := AddOrderAction{
+		Metadata:    *req,
+		ShardID:     shardID,
+		RequestTxID: *tx.Hash(),
+	}
+	b, err := json.Marshal(action)
+	if err != nil {
+		return [][]string{}, err
+	}
+	actionEncoded := base64.StdEncoding.EncodeToString(b)
+	return [][]string{
+		[]string{
+			strconv.Itoa(metadataCommon.PDexV3AddOrderRequestMeta),
+			actionEncoded,
+		},
+	}, nil
+}
+
+func (req *AddOrderRequest) CalculateSize() uint64 {
+	return metadataCommon.CalculateSize(req)
+}
+
+func (req *AddOrderRequest) GetOTADeclarations() []metadataCommon.OTADeclaration {
+	var result []metadataCommon.OTADeclaration
+	sellingToken := common.ConfidentialAssetID
+	if req.TokenToSell == common.PRVCoinID {
+		sellingToken = common.PRVCoinID
+	}
+	result = append(result, metadataCommon.OTADeclaration{PublicKey: req.RefundReceiver.PublicKey.ToBytes(), TokenID: sellingToken})
+	return result
+}

--- a/metadata/pdexv3/addOrder.go
+++ b/metadata/pdexv3/addOrder.go
@@ -15,6 +15,7 @@ import (
 type AddOrderRequest struct {
 	TokenToSell         common.Hash         `json:"TokenToSell"`
 	TokenToBuy          common.Hash         `json:"TokenToBuy"`
+	PairID              string              `json:"PairID"`
 	SellAmount          uint64              `json:"SellAmount"`
 	MinAcceptableAmount uint64              `json:"MinAcceptableAmount"`
 	TradingFee          uint64              `json:"TradingFee"`
@@ -29,10 +30,12 @@ type AddOrderAction struct {
 }
 
 type AcceptedAddOrder struct {
-	TokenToBuy  common.Hash `json:"TokenToBuy"`
-	PairID      string      `json:"PairID"`
-	ShardID     byte        `json:"ShardID"`
-	RequestTxID common.Hash `json:"RequestTxID"`
+	TokenToBuy          common.Hash `json:"TokenToBuy"`
+	PairID              string      `json:"PairID"`
+	SellAmount          uint64      `json:"SellAmount"`
+	MinAcceptableAmount uint64      `json:"MinAcceptableAmount"`
+	ShardID             byte        `json:"ShardID"`
+	RequestTxID         common.Hash `json:"RequestTxID"`
 }
 
 type RefundedAddOrder struct {
@@ -46,6 +49,7 @@ type RefundedAddOrder struct {
 func NewAddOrderRequest(
 	tokenToBuy common.Hash,
 	tokenToSell common.Hash,
+	pairID string,
 	sellAmount uint64,
 	minAcceptableAmount uint64,
 	tradingFee uint64,
@@ -55,6 +59,7 @@ func NewAddOrderRequest(
 	pdeTradeRequest := &AddOrderRequest{
 		TokenToSell:         tokenToSell,
 		TokenToBuy:          tokenToBuy,
+		PairID:              pairID,
 		SellAmount:          sellAmount,
 		MinAcceptableAmount: minAcceptableAmount,
 		TradingFee:          tradingFee,

--- a/metadata/pdexv3/trade.go
+++ b/metadata/pdexv3/trade.go
@@ -1,0 +1,126 @@
+package metadata
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"strconv"
+
+	"github.com/incognitochain/incognito-chain/common"
+	"github.com/incognitochain/incognito-chain/dataaccessobject/statedb"
+	metadataCommon "github.com/incognitochain/incognito-chain/metadata/common"
+	"github.com/incognitochain/incognito-chain/privacy"
+)
+
+// TradeRequest
+type TradeRequest struct {
+	TokenToSell         common.Hash         `json:"TokenToSell"`
+	TokenToBuy          common.Hash         `json:"TokenToBuy"`
+	SellAmount          uint64              `json:"SellAmount"`
+	MinAcceptableAmount uint64              `json:"MinAcceptableAmount"`
+	TradingFee          uint64              `json:"TradingFee"`
+	Receiver            privacy.OTAReceiver `json:"Receiver"`
+	RefundReceiver      privacy.OTAReceiver `json:"RefundReceiver"`
+	metadataCommon.MetadataBase
+}
+
+type TradeAction struct {
+	Metadata    TradeRequest `json:"Metadata"`
+	ShardID     byte         `json:"ShardID"`
+	RequestTxID common.Hash  `json:"RequestTxID"`
+}
+
+type AcceptedTrade struct {
+	Receiver      privacy.OTAReceiver `json:"Receiver"`
+	ReceiveAmount uint64              `json:"ReceiveAmount"`
+	TokenToBuy    common.Hash         `json:"TokenToBuy"`
+	PairID        string              `json:"PairID"`
+	Token0Change  big.Int             `json:"Token0Change"`
+	Token1Change  big.Int             `json:"Token1Change"`
+	ShardID       byte                `json:"ShardID"`
+	RequestTxID   common.Hash         `json:"RequestTxID"`
+}
+
+type RefundedTrade struct {
+	Receiver    privacy.OTAReceiver `json:"Receiver"`
+	TokenToSell common.Hash         `json:"TokenToSell"`
+	Amount      uint64              `json:"Amount"`
+	ShardID     byte                `json:"ShardID`
+	RequestTxID common.Hash         `json:"RequestTxID"`
+}
+
+func NewTradeRequest(
+	tokenToBuy common.Hash,
+	tokenToSell common.Hash,
+	sellAmount uint64,
+	minAcceptableAmount uint64,
+	tradingFee uint64,
+	recv, refundRecv privacy.OTAReceiver,
+	metaType int,
+) (*TradeRequest, error) {
+	pdeTradeRequest := &TradeRequest{
+		TokenToSell:         tokenToSell,
+		TokenToBuy:          tokenToBuy,
+		SellAmount:          sellAmount,
+		MinAcceptableAmount: minAcceptableAmount,
+		TradingFee:          tradingFee,
+		Receiver:            recv,
+		RefundReceiver:      refundRecv,
+		MetadataBase: metadataCommon.MetadataBase{
+			Type: metaType,
+		},
+	}
+	return pdeTradeRequest, nil
+}
+
+func (req TradeRequest) ValidateTxWithBlockChain(tx metadataCommon.Transaction, chainRetriever metadataCommon.ChainRetriever, shardViewRetriever metadataCommon.ShardViewRetriever, beaconViewRetriever metadataCommon.BeaconViewRetriever, shardID byte, transactionStateDB *statedb.StateDB) (bool, error) {
+	return true, nil
+}
+
+func (req TradeRequest) ValidateSanityData(chainRetriever metadataCommon.ChainRetriever, shardViewRetriever metadataCommon.ShardViewRetriever, beaconViewRetriever metadataCommon.BeaconViewRetriever, beaconHeight uint64, tx metadataCommon.Transaction) (bool, bool, error) {
+	return true, true, nil
+}
+
+func (req TradeRequest) ValidateMetadataByItself() bool {
+	return req.Type == metadataCommon.PDexV3TradeRequestMeta
+}
+
+func (req TradeRequest) Hash() *common.Hash {
+	rawBytes, _ := json.Marshal(req)
+	hash := common.HashH([]byte(rawBytes))
+	return &hash
+}
+
+func (req *TradeRequest) BuildReqActions(tx metadataCommon.Transaction, chainRetriever metadataCommon.ChainRetriever, shardViewRetriever metadataCommon.ShardViewRetriever, beaconViewRetriever metadataCommon.BeaconViewRetriever, shardID byte, shardHeight uint64) ([][]string, error) {
+	action := TradeAction{
+		Metadata:    *req,
+		ShardID:     shardID,
+		RequestTxID: *tx.Hash(),
+	}
+	b, err := json.Marshal(action)
+	if err != nil {
+		return [][]string{}, err
+	}
+	actionEncoded := base64.StdEncoding.EncodeToString(b)
+	return [][]string{
+		[]string{
+			strconv.Itoa(metadataCommon.PDexV3TradeRequestMeta),
+			actionEncoded,
+		},
+	}, nil
+}
+
+func (req *TradeRequest) CalculateSize() uint64 {
+	return metadataCommon.CalculateSize(req)
+}
+
+func (req *TradeRequest) GetOTADeclarations() []metadataCommon.OTADeclaration {
+	var result []metadataCommon.OTADeclaration
+	sellingToken := common.ConfidentialAssetID
+	if req.TokenToSell == common.PRVCoinID {
+		sellingToken = common.PRVCoinID
+	}
+	result = append(result, metadataCommon.OTADeclaration{PublicKey: req.Receiver.PublicKey.ToBytes(), TokenID: sellingToken})
+	result = append(result, metadataCommon.OTADeclaration{PublicKey: req.RefundReceiver.PublicKey.ToBytes(), TokenID: common.PRVCoinID})
+	return result
+}

--- a/metadata/pdexv3/trade.go
+++ b/metadata/pdexv3/trade.go
@@ -14,8 +14,7 @@ import (
 
 // TradeRequest
 type TradeRequest struct {
-	TokenToSell         common.Hash         `json:"TokenToSell"`
-	TokenToBuy          common.Hash         `json:"TokenToBuy"`
+	TradePath           []common.Hash       `json:"TradePath"`
 	SellAmount          uint64              `json:"SellAmount"`
 	MinAcceptableAmount uint64              `json:"MinAcceptableAmount"`
 	TradingFee          uint64              `json:"TradingFee"`
@@ -50,8 +49,7 @@ type RefundedTrade struct {
 }
 
 func NewTradeRequest(
-	tokenToBuy common.Hash,
-	tokenToSell common.Hash,
+	tradePath []common.Hash,
 	sellAmount uint64,
 	minAcceptableAmount uint64,
 	tradingFee uint64,
@@ -59,8 +57,7 @@ func NewTradeRequest(
 	metaType int,
 ) (*TradeRequest, error) {
 	pdeTradeRequest := &TradeRequest{
-		TokenToSell:         tokenToSell,
-		TokenToBuy:          tokenToBuy,
+		TradePath:           tradePath,
 		SellAmount:          sellAmount,
 		MinAcceptableAmount: minAcceptableAmount,
 		TradingFee:          tradingFee,

--- a/metadata/pdexv3/trade.go
+++ b/metadata/pdexv3/trade.go
@@ -91,25 +91,6 @@ func (req TradeRequest) Hash() *common.Hash {
 	return &hash
 }
 
-func (req *TradeRequest) BuildReqActions(tx metadataCommon.Transaction, chainRetriever metadataCommon.ChainRetriever, shardViewRetriever metadataCommon.ShardViewRetriever, beaconViewRetriever metadataCommon.BeaconViewRetriever, shardID byte, shardHeight uint64) ([][]string, error) {
-	action := TradeAction{
-		Metadata:    *req,
-		ShardID:     shardID,
-		RequestTxID: *tx.Hash(),
-	}
-	b, err := json.Marshal(action)
-	if err != nil {
-		return [][]string{}, err
-	}
-	actionEncoded := base64.StdEncoding.EncodeToString(b)
-	return [][]string{
-		[]string{
-			strconv.Itoa(metadataCommon.PDexV3TradeRequestMeta),
-			actionEncoded,
-		},
-	}, nil
-}
-
 func (req *TradeRequest) CalculateSize() uint64 {
 	return metadataCommon.CalculateSize(req)
 }

--- a/privacy/coin/receiver.go
+++ b/privacy/coin/receiver.go
@@ -1,0 +1,52 @@
+package coin
+
+import (
+	"errors"
+	"github.com/incognitochain/incognito-chain/common"
+	"github.com/incognitochain/incognito-chain/common/base58"
+	"github.com/incognitochain/incognito-chain/privacy/operation"
+	"github.com/incognitochain/incognito-chain/wallet"
+)
+
+type OTAReceiver struct {
+	PublicKey 	operation.Point
+	TxRandom 	TxRandom
+}
+
+func ParseReceiver(data string) (*OTAReceiver, error) {
+	result := &OTAReceiver{}
+	raw, _, err := base58.Base58Check{}.Decode(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, errors.New("Not enough bytes to parse ReceivingAddress")
+	}
+	keyType := raw[0]
+	switch keyType {
+	case wallet.PrivateReceivingAddressType:
+		buf := make([]byte, 32)
+		copy(buf, raw[1:33])
+		pk, err := (&operation.Point{}).FromBytesS(buf)
+		if err != nil {
+			return nil, err
+		}
+		result.PublicKey = *pk
+		txr := NewTxRandom()
+		err = txr.SetBytes(raw[33:])
+		if err != nil {
+			return nil, err
+		}
+		result.TxRandom = *txr
+		return result, nil
+	default:
+		return nil, errors.New("Unrecognized prefix for ReceivingAddress")
+	}
+}
+
+func (recv OTAReceiver) String() (string, error) {
+	rawBytes := []byte{byte(wallet.PrivateReceivingAddressType)}
+	rawBytes = append(rawBytes, recv.PublicKey.ToBytesS()...)
+	rawBytes = append(rawBytes, recv.TxRandom.Bytes()...)
+	return base58.Base58Check{}.NewEncode(rawBytes, common.ZeroByte), nil
+}

--- a/privacy/coin/receiver.go
+++ b/privacy/coin/receiver.go
@@ -1,52 +1,118 @@
 package coin
 
 import (
+	"encoding/json"
 	"errors"
+
 	"github.com/incognitochain/incognito-chain/common"
 	"github.com/incognitochain/incognito-chain/common/base58"
 	"github.com/incognitochain/incognito-chain/privacy/operation"
 	"github.com/incognitochain/incognito-chain/wallet"
 )
 
+// OTAReceiver holds the data necessary to send a coin to your receiver with privacy.
+// It is somewhat equivalent in usage with PaymentAddress
 type OTAReceiver struct {
-	PublicKey 	operation.Point
-	TxRandom 	TxRandom
+	PublicKey operation.Point
+	TxRandom  TxRandom
 }
 
-func ParseReceiver(data string) (*OTAReceiver, error) {
-	result := &OTAReceiver{}
+// IsValid() checks the validity of this OTAReceiver (all referenced Points must be valid).
+// Note that some sanity checks are already done when unmarshalling
+func (recv OTAReceiver) IsValid() bool {
+	_, err := recv.TxRandom.GetTxConcealRandomPoint()
+	if err != nil {
+		return false
+	}
+	_, err = recv.TxRandom.GetTxOTARandomPoint()
+	if err != nil {
+		return false
+	}
+	return recv.PublicKey.PointValid()
+}
+
+// FromString() returns a new OTAReceiver parsed from the input string,
+// or error on failure
+func (recv *OTAReceiver) FromString(data string) (error) {
+	if recv == nil {
+		return errors.New("OTAReceiver not initialized")
+	}
 	raw, _, err := base58.Base58Check{}.Decode(data)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if len(raw) == 0 {
-		return nil, errors.New("Not enough bytes to parse ReceivingAddress")
+	err = recv.SetBytes(raw)
+	if err != nil {
+		return err
 	}
-	keyType := raw[0]
-	switch keyType {
-	case wallet.PrivateReceivingAddressType:
-		buf := make([]byte, 32)
-		copy(buf, raw[1:33])
-		pk, err := (&operation.Point{}).FromBytesS(buf)
-		if err != nil {
-			return nil, err
-		}
-		result.PublicKey = *pk
-		txr := NewTxRandom()
-		err = txr.SetBytes(raw[33:])
-		if err != nil {
-			return nil, err
-		}
-		result.TxRandom = *txr
-		return result, nil
-	default:
-		return nil, errors.New("Unrecognized prefix for ReceivingAddress")
-	}
+	return nil
 }
 
+// String() marshals the OTAReceiver, then encodes it with base58
 func (recv OTAReceiver) String() (string, error) {
+	rawBytes, err := recv.Bytes()
+	if err != nil {
+		return "", err
+	}
+	return base58.Base58Check{}.NewEncode(rawBytes, common.ZeroByte), nil
+}
+
+func (recv OTAReceiver) Bytes() ([]byte, error) {
 	rawBytes := []byte{byte(wallet.PrivateReceivingAddressType)}
 	rawBytes = append(rawBytes, recv.PublicKey.ToBytesS()...)
 	rawBytes = append(rawBytes, recv.TxRandom.Bytes()...)
-	return base58.Base58Check{}.NewEncode(rawBytes, common.ZeroByte), nil
+	return rawBytes, nil
+}
+
+func (recv *OTAReceiver) SetBytes(b []byte) error {
+	if len(b) == 0 {
+		return errors.New("Not enough bytes to parse ReceivingAddress")
+	}
+	if recv == nil {
+		return errors.New("OTAReceiver not initialized")
+	}
+	keyType := b[0]
+	switch keyType {
+	case wallet.PrivateReceivingAddressType:
+		buf := make([]byte, 32)
+		copy(buf, b[1:33])
+		pk, err := (&operation.Point{}).FromBytesS(buf)
+		if err != nil {
+			return err
+		}
+		recv.PublicKey = *pk
+		txr := NewTxRandom()
+		// SetBytes() will perform length check
+		err = txr.SetBytes(b[33:])
+		if err != nil {
+			return err
+		}
+		recv.TxRandom = *txr
+		return nil
+	default:
+		return errors.New("Unrecognized prefix for ReceivingAddress")
+	}
+}
+
+func (recv OTAReceiver) MarshalJSON() ([]byte, error) {
+	s, err := recv.String()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(s)
+}
+
+func (recv *OTAReceiver) UnmarshalJSON(raw []byte) error {
+	var encodedString string
+	err := json.Unmarshal(raw, &encodedString)
+	if err != nil {
+		return err
+	}
+	var temp OTAReceiver
+	err = temp.FromString(encodedString)
+	if err != nil {
+		return err
+	}
+	*recv = temp
+	return nil
 }

--- a/privacy/coin/receiver_test.go
+++ b/privacy/coin/receiver_test.go
@@ -1,0 +1,95 @@
+package coin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/incognitochain/incognito-chain/common"
+	"github.com/incognitochain/incognito-chain/common/base58"
+	"github.com/incognitochain/incognito-chain/privacy/operation"
+	. "github.com/stretchr/testify/assert"
+)
+
+func TestOTAReceiverMarshal(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		r := randomOTAReceiver()
+		True(t, r.IsValid())
+		jsonBytes, err := json.Marshal(r)
+		NoError(t, err)
+		rawBytes, err := r.Bytes()
+		NoError(t, err)
+		Len(t, rawBytes, 33+TxRandomGroupSize)
+		var rAgain OTAReceiver
+		err = json.Unmarshal(jsonBytes, &rAgain)
+		NoError(t, err)
+		jsonBytesAgain, err := json.Marshal(rAgain)
+		NoError(t, err)
+		True(t, bytes.Equal(jsonBytesAgain, jsonBytes))
+	}
+}
+
+func TestOTAReceiverValid(t *testing.T) {
+	type Testcase struct {
+		name     string
+		data     string
+		expected bool
+	}
+
+	testcases := []Testcase{
+		Testcase{"Valid1", "15sXoyo8kCZCHjurNC69b8WV2jMCvf5tVrcQ5mT1eH9Nm351XRjE1BH4WHHLGYPZy9dxTSLiKQd6KdfoGq4yb4gP1AU2oaJTeoGymsEzonyi1XSW2J2U7LeAVjS1S2gjbNDk1t3f9QUg2gk4", true},
+		Testcase{"Valid2", "15ujixNQY1Qc5wyX9UYQW3s6cbcecFPNhrWjWiFCggeN5HukPVdjbKyRE3goUpFgZhawtBtRUK3ZSZb5LtH7bevhGzz3UTh1muzLHG3pvsE6RNB81y8xNGhyHdpHZfjwmSWDdwDe74Tg2CUP", true},
+		Testcase{"Valid3", "16Q5kgtmmue79rCYHgnJpuTxwTbbXZQXZUgC65Tngkd6brUByi2ZQG1tz3xbu8Lq7H35szf2MALE6Hn4vFJqUBqeYWtLFonFe81P5hWgR47zP6xxbdC76G7Fh2fqyXHcdJwJRTgtc4Jj8SUT", true},
+		Testcase{"Invalid - extra byte", "1R1sARaqtyxsZaxbyKUYGxJADoYnLrDewtkhvCr2aYTmPSgEc68T2LbDKjH1YuGY9FRZKkJQFZSfrXqexrQ92naQ8PdXumDKc9cyqCFEUFfPvYJYrUjEhhNfcdHkeiRsPUDEQZC3VQGwpWnjU", false},
+		Testcase{"Invalid - extra point", "12ckAL4NW2XGdQFDRJXY6g2kCwp8QNzCqCGaP3jpzZ4wq1kntGWbZExc1MVHvXAaw8abNPaNSzJWBfMG9PdA2nvWq9wBv2PWyEqzKbb3trw7jMDQZV6KfWKkN9UWGv1TrQYAypmVtzbTrHoe3N6gcNg3rFMpa3YSm99a2Whm38BMATPxw2wnVeLJsca6", false},
+		Testcase{"Invalid - key type", "12w5UVxaMedfp1W5rKaCJE8Bh15VxJQjyDRV6Dh7DMhUM5wGF9ZSGwevhy2YFSGAA4chLWJm4jj9qjXdXVAThaCyTNMQD7w9rWLvFCSDB2gb9fpb7hkKvLFCJCDNV6iYDGjpuejjc4dXG9qgH", false},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			var r OTAReceiver
+			err := r.FromString(testcase.data)
+			Equal(t, err==nil, testcase.expected)
+			// data that fail IsValid() will not unmarshal successfully
+			// Equal(t, r.IsValid(), testcase.expected)
+		})
+	}
+}
+
+func showExampleOTAReceivers() {
+	fmt.Println("Valid")
+	for i := 0; i < 3; i++ {
+		r := randomOTAReceiver()
+		s, _ := r.String()
+		fmt.Println(s)
+	}
+	fmt.Println("Invalid")
+	r := randomOTAReceiver()
+	tempBytes, _ := r.Bytes()
+	tempBytes = append(tempBytes, byte(rand.Int31()))
+	invalidOTAReceiver := base58.Base58Check{}.NewEncode(tempBytes, common.ZeroByte)
+	fmt.Println(invalidOTAReceiver)
+
+	tempBytes, _ = r.Bytes()
+	tempBytes = append(tempBytes, operation.RandomPoint().ToBytesS()...)
+	invalidOTAReceiver = base58.Base58Check{}.NewEncode(tempBytes, common.ZeroByte)
+	fmt.Println(invalidOTAReceiver)
+
+	tempBytes, _ = r.Bytes()
+	tempBytes[0] = 99
+	invalidOTAReceiver = base58.Base58Check{}.NewEncode(tempBytes, common.ZeroByte)
+	fmt.Println(invalidOTAReceiver)
+}
+
+func randomOTAReceiver() OTAReceiver {
+	txr := NewTxRandom()
+	txr.SetTxOTARandomPoint(operation.RandomPoint())
+	txr.SetTxConcealRandomPoint(operation.RandomPoint())
+	txr.SetIndex(rand.Uint32())
+	return OTAReceiver{
+		PublicKey: *operation.RandomPoint(),
+		TxRandom:  *txr,
+	}
+}

--- a/privacy/privacy_exports.go
+++ b/privacy/privacy_exports.go
@@ -99,6 +99,7 @@ type CoinV1 = coin.CoinV1
 type CoinV2 = coin.CoinV2
 type CoinObject = coin.CoinObject
 type TxRandom = coin.TxRandom
+type OTAReceiver = coin.OTAReceiver
 
 type Proof = proof.Proof
 type ProofV1 = zkp.PaymentProof

--- a/wallet/constants.go
+++ b/wallet/constants.go
@@ -22,5 +22,6 @@ const (
 	PriKeyType         = byte(0x0) // Serialize wallet account key into string with only PRIVATE KEY of account keyset
 	PaymentAddressType = byte(0x1) // Serialize wallet account key into string with only PAYMENT ADDRESS of account keyset
 	ReadonlyKeyType    = byte(0x2) // Serialize wallet account key into string with only READONLY KEY of account keyset
-	OTAKeyType         = byte(0x3) // Serialize wallet account key into string with only OTA KEY of account keyset
+	OTAKeyType		   = byte(0x3) // Serialize wallet account key into string with only OTA KEY of account keyset
+	PrivateReceivingAddressType = byte(0x4) // prefix for marshalled receiving address (coin pk + txRandom), not used for KeyWallet
 )


### PR DESCRIPTION
- define new metadata types + constants for trade & addOrder flow
- define OTAReceiver struct as `privacy` substitute for PaymentAddress when sending coin
- move `calculateSize` to `metadata/common`
- future work : withdrawOrder metadata; validation functions