### PR TITLE
Change object types from iota enum to hard code values

### DIFF
--- a/dataaccessobject/statedb/constants.go
+++ b/dataaccessobject/statedb/constants.go
@@ -7,60 +7,60 @@ const (
 
 // Object type
 const (
-	TestObjectType = iota
-	CommitteeObjectType
-	CommitteeRewardObjectType
-	RewardRequestObjectType
-	BlackListProducerObjectType
-	SerialNumberObjectType
-	CommitmentObjectType
-	CommitmentIndexObjectType
-	CommitmentLengthObjectType
-	SNDerivatorObjectType
-	OutputCoinObjectType
-	OTACoinObjectType
-	OTACoinIndexObjectType
-	OTACoinLengthObjectType
-	OnetimeAddressObjectType
-	TokenObjectType
-	WaitingPDEContributionObjectType
-	PDEPoolPairObjectType
-	PDEShareObjectType
-	PDEStatusObjectType
-	BridgeEthTxObjectType
-	BridgeTokenInfoObjectType
-	BridgeStatusObjectType
-	BurningConfirmObjectType
-	TokenTransactionObjectType
+	TestObjectType                   = 0
+	CommitteeObjectType              = 1
+	CommitteeRewardObjectType        = 2
+	RewardRequestObjectType          = 3
+	BlackListProducerObjectType      = 4
+	SerialNumberObjectType           = 5
+	CommitmentObjectType             = 6
+	CommitmentIndexObjectType        = 7
+	CommitmentLengthObjectType       = 8
+	SNDerivatorObjectType            = 9
+	OutputCoinObjectType             = 10
+	OTACoinObjectType                = 11
+	OTACoinIndexObjectType           = 12
+	OTACoinLengthObjectType          = 13
+	OnetimeAddressObjectType         = 14
+	TokenObjectType                  = 15
+	WaitingPDEContributionObjectType = 16
+	PDEPoolPairObjectType            = 17
+	PDEShareObjectType               = 18
+	PDEStatusObjectType              = 19
+	BridgeEthTxObjectType            = 20
+	BridgeTokenInfoObjectType        = 21
+	BridgeStatusObjectType           = 22
+	BurningConfirmObjectType         = 23
+	TokenTransactionObjectType       = 24
 
 	// portal
 	//final exchange rates
-	PortalFinalExchangeRatesStateObjectType
+	PortalFinalExchangeRatesStateObjectType = 25
 	//waiting porting request
-	PortalWaitingPortingRequestObjectType
+	PortalWaitingPortingRequestObjectType = 26
 	//liquidation
-	PortalLiquidationPoolObjectType
-	PortalStatusObjectType
-	CustodianStateObjectType
-	WaitingRedeemRequestObjectType
-	PortalRewardInfoObjectType
-	LockedCollateralStateObjectType
-	RewardFeatureStateObjectType
+	PortalLiquidationPoolObjectType = 27
+	PortalStatusObjectType          = 28
+	CustodianStateObjectType        = 29
+	WaitingRedeemRequestObjectType  = 30
+	PortalRewardInfoObjectType      = 31
+	LockedCollateralStateObjectType = 32
+	RewardFeatureStateObjectType    = 33
 
 	// PDEX v2
-	PDETradingFeeObjectType
+	PDETradingFeeObjectType = 34
 
-	StakerObjectType
+	StakerObjectType = 35
 
 	// Portal v3
-	PortalExternalTxObjectType
-	PortalConfirmProofObjectType
-	PortalUnlockOverRateCollaterals
+	PortalExternalTxObjectType      = 36
+	PortalConfirmProofObjectType    = 37
+	PortalUnlockOverRateCollaterals = 38
 
-	SlashingCommitteeObjectType
+	SlashingCommitteeObjectType = 39
 
 	// bsc bridge
-	BridgeBSCTxObjectType
+	BridgeBSCTxObjectType = 40
 )
 
 // Prefix length


### PR DESCRIPTION
Avoid mistakes when creating new state objects that can corrupt the StateDB