### PR TITLE
[hotfix] get committee with block version

### DIFF
--- a/blockchain/shardbeststate.go
+++ b/blockchain/shardbeststate.go
@@ -600,9 +600,9 @@ func (shardBestState *ShardBestState) getSigningCommittees(
 		return shardBestState.GetShardCommittee(), shardBestState.GetShardCommittee(), nil
 	}
 	switch shardBlock.Header.Version {
-	case types.BFT_VERSION, types.MULTI_VIEW_VERSION:
+	case types.BFT_VERSION:
 		return shardBestState.GetShardCommittee(), shardBestState.GetShardCommittee(), nil
-	case types.SHARD_SFV2_VERSION, types.SHARD_SFV3_VERSION:
+	case types.MULTI_VIEW_VERSION, types.SHARD_SFV2_VERSION, types.SHARD_SFV3_VERSION:
 		committees, err := bc.getShardCommitteeForBlockProducing(shardBlock.CommitteeFromBlock(), shardBlock.Header.ShardID)
 		if err != nil {
 			return []incognitokey.CommitteePublicKey{}, []incognitokey.CommitteePublicKey{}, err


### PR DESCRIPTION
Testnet 2: block created by staking flow v2 should have version 3, but somehow some block got version 2 only