### PR TITLE
[pdex-v3] implement burn-only tokens; update coin picker for ringSig

### DIFF
--- a/blockchain/beaconbeststate.go
+++ b/blockchain/beaconbeststate.go
@@ -620,6 +620,16 @@ func (beaconBestState *BeaconBestState) IsValidPdexv3LP(poolPairID, lpID string)
 	return beaconBestState.pdeStates[pdex.AmplifierVersion].Validator().IsValidLP(poolPairID, lpID)
 }
 
+func (beaconBestState *BeaconBestState) NftIDCoinFilter() (*privacy.TokenIDRingDecoyFilter, error) {
+	data, err := beaconBestState.pdeStates[pdex.AmplifierVersion].Reader().NFTAssetTags()
+	if err != nil {
+		return nil, err
+	}
+	return &privacy.TokenIDRingDecoyFilter {
+		Data: data,
+	}, nil
+}
+
 func (beaconBestState *BeaconBestState) GetAllCommitteeValidatorCandidate() (map[byte][]incognitokey.CommitteePublicKey, map[byte][]incognitokey.CommitteePublicKey, map[byte][]incognitokey.CommitteePublicKey, []incognitokey.CommitteePublicKey, []incognitokey.CommitteePublicKey, []incognitokey.CommitteePublicKey, []incognitokey.CommitteePublicKey, []incognitokey.CommitteePublicKey, []incognitokey.CommitteePublicKey, error) {
 	sC := make(map[byte][]incognitokey.CommitteePublicKey)
 	sPV := make(map[byte][]incognitokey.CommitteePublicKey)

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -28,6 +28,7 @@ import (
 	"github.com/incognitochain/incognito-chain/memcache"
 	"github.com/incognitochain/incognito-chain/metadata"
 	"github.com/incognitochain/incognito-chain/multiview"
+	"github.com/incognitochain/incognito-chain/privacy"
 	"github.com/incognitochain/incognito-chain/privacy/coin"
 	bnbrelaying "github.com/incognitochain/incognito-chain/relaying/bnb"
 	btcrelaying "github.com/incognitochain/incognito-chain/relaying/btc"
@@ -426,8 +427,12 @@ func (blockchain BlockChain) RandomCommitmentsAndPublicKeysProcess(numOutputs in
 		}
 
 		publicKey := coinDB.GetPublicKey()
-		// we do not use burned coins since they will reduce the privacy level of the transaction.
+		// we do not use burned or burn-only coins since they will reduce the privacy level of the transaction.
 		if common.IsPublicKeyBurningAddress(publicKey.ToBytesS()) {
+			i--
+			continue
+		}
+		if found, _, _, _ := privacy.ContainsNonPrivateToken([][]*privacy.CoinV2{[]*privacy.CoinV2{coinDB}}); found {
 			i--
 			continue
 		}

--- a/blockchain/pdex/interface.go
+++ b/blockchain/pdex/interface.go
@@ -1,5 +1,9 @@
 package pdex
 
+import (
+	"github.com/incognitochain/incognito-chain/common"
+)
+
 type State interface {
 	Version() uint
 	Clone() State
@@ -21,6 +25,7 @@ type StateReader interface {
 	TradingFees() map[string]uint64
 	NftIDs() map[string]uint64
 	StakingPools() map[string]*StakingPoolState
+	NFTAssetTags() (map[string]*common.Hash, error)
 }
 
 type StateValidator interface {

--- a/blockchain/pdex/state_base.go
+++ b/blockchain/pdex/state_base.go
@@ -1,6 +1,9 @@
 package pdex
 
-import "github.com/incognitochain/incognito-chain/blockchain/pdex/v2utils"
+import (
+	"github.com/incognitochain/incognito-chain/blockchain/pdex/v2utils"
+	"github.com/incognitochain/incognito-chain/common"
+)
 
 type stateBase struct {
 }
@@ -114,5 +117,9 @@ func (s *stateBase) IsValidLP(poolPairID, nftID string) (bool, error) {
 }
 
 func (s *stateBase) Validator() StateValidator {
+	panic("Implement this function")
+}
+
+func (s *stateBase) NFTAssetTags() (map[string]*common.Hash, error) {
 	panic("Implement this function")
 }

--- a/blockchain/pdex/state_processor_v2.go
+++ b/blockchain/pdex/state_processor_v2.go
@@ -1042,7 +1042,7 @@ func (sp *stateProcessorV2) mintBlockReward(
 }
 
 func (sp *stateProcessorV2) userMintNft(
-	stateDB *statedb.StateDB, inst []string, nftIDs map[string]uint64,
+	stateDB *statedb.StateDB, inst []string, nftIDs map[string]uint64, nftAssetTags *v2utils.NFTAssetTagsCache,
 ) (map[string]uint64, *v2.MintNftStatus, error) {
 	if len(inst) != 3 {
 		return nftIDs, nil, fmt.Errorf("Expect length of instruction is %v but get %v", 3, len(inst))
@@ -1073,6 +1073,7 @@ func (sp *stateProcessorV2) userMintNft(
 		nftID = acceptInst.NftID().String()
 		burntAmount = acceptInst.BurntAmount()
 		nftIDs[acceptInst.NftID().String()] = acceptInst.BurntAmount()
+		nftAssetTags.Add(acceptInst.NftID())
 		txReqID = acceptInst.TxReqID()
 		status = common.Pdexv3AcceptStatus
 	default:

--- a/blockchain/pdex/state_processor_v2_test.go
+++ b/blockchain/pdex/state_processor_v2_test.go
@@ -1106,7 +1106,9 @@ func Test_stateProcessorV2_userMintNft(t *testing.T) {
 				withdrawTxCache:    tt.fields.withdrawTxCache,
 				stateProcessorBase: tt.fields.stateProcessorBase,
 			}
-			got, got1, err := sp.userMintNft(tt.args.stateDB, tt.args.inst, tt.args.nftIDs)
+			atc, err := (&v2utils.NFTAssetTagsCache{}).FromIDs(tt.args.nftIDs)
+			assert.Nil(t, err)
+			got, got1, err := sp.userMintNft(tt.args.stateDB, tt.args.inst, tt.args.nftIDs, atc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("stateProcessorV2.userMintNft() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1116,6 +1118,13 @@ func Test_stateProcessorV2_userMintNft(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got1, tt.want1) {
 				t.Errorf("stateProcessorV2.userMintNft() got1 = %v, want %v", got1, tt.want1)
+			}
+
+			// check assetTagsCache consistency
+			expectedAtc, err := (&v2utils.NFTAssetTagsCache{}).FromIDs(tt.want)
+			assert.Nil(t, err)
+			if !reflect.DeepEqual(atc, expectedAtc) {
+				t.Errorf("stateProcessorV2.userMintNft() got1 = %v, want %v", atc, expectedAtc)
 			}
 		})
 	}

--- a/blockchain/pdex/state_producer_v2.go
+++ b/blockchain/pdex/state_producer_v2.go
@@ -1369,6 +1369,7 @@ func (sp *stateProducerV2) withdrawLiquidity(
 func (sp *stateProducerV2) userMintNft(
 	txs []metadata.Transaction,
 	nftIDs map[string]uint64,
+	nftAssetTags *v2utils.NFTAssetTagsCache,
 	beaconHeight, mintNftRequireAmount uint64,
 ) ([][]string, map[string]uint64, uint64, error) {
 	res := [][]string{}
@@ -1389,6 +1390,7 @@ func (sp *stateProducerV2) userMintNft(
 		} else {
 			nftID := genNFT(uint64(len(nftIDs)), beaconHeight)
 			nftIDs[nftID.String()] = metaData.Amount()
+			nftAssetTags.Add(nftID)
 			inst, err = instruction.NewAcceptUserMintNftWithValue(
 				metaData.OtaReceiver(), metaData.Amount(), shardID, nftID, txReqID,
 			).StringSlice()

--- a/blockchain/pdex/state_producer_v2_test.go
+++ b/blockchain/pdex/state_producer_v2_test.go
@@ -2223,7 +2223,9 @@ func Test_stateProducerV2_userMintNft(t *testing.T) {
 			sp := &stateProducerV2{
 				stateProducerBase: tt.fields.stateProducerBase,
 			}
-			got, got1, _, err := sp.userMintNft(tt.args.txs, tt.args.nftIDs, tt.args.beaconHeight, tt.args.mintNftRequireAmount)
+			atc, err := (&v2utils.NFTAssetTagsCache{}).FromIDs(tt.args.nftIDs)
+			assert.Nil(t, err)
+			got, got1, _, err := sp.userMintNft(tt.args.txs, tt.args.nftIDs, atc, tt.args.beaconHeight, tt.args.mintNftRequireAmount)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("stateProducerV2.userMintNft() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -2233,6 +2235,13 @@ func Test_stateProducerV2_userMintNft(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got1, tt.want1) {
 				t.Errorf("stateProducerV2.userMintNft() got1 = %v, want %v", got1, tt.want1)
+			}
+
+			// check assetTagsCache consistency
+			expectedAtc, err := (&v2utils.NFTAssetTagsCache{}).FromIDs(tt.want1)
+			assert.Nil(t, err)
+			if !reflect.DeepEqual(atc, expectedAtc) {
+				t.Errorf("stateProcessorV2.userMintNft() got1 = %v, want %v", atc, expectedAtc)
 			}
 		})
 	}

--- a/blockchain/pdex/state_v1.go
+++ b/blockchain/pdex/state_v1.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/incognitochain/incognito-chain/blockchain/pdex/v2utils"
+	"github.com/incognitochain/incognito-chain/common"
 	"github.com/incognitochain/incognito-chain/dataaccessobject/rawdbv2"
 	"github.com/incognitochain/incognito-chain/dataaccessobject/statedb"
 	"github.com/incognitochain/incognito-chain/metadata"
@@ -447,3 +448,5 @@ func (s *stateV1) IsValidPdexv3PoolPairID(poolPairID string) (bool, error) {
 	}
 	return true, nil
 }
+
+func (s *stateV1) NFTAssetTags() (map[string]*common.Hash, error) { return nil, nil }

--- a/blockchain/pdex/state_v2.go
+++ b/blockchain/pdex/state_v2.go
@@ -817,7 +817,11 @@ func (s *stateV2) IsValidLP(poolPairID, lpID string) (bool, error) {
 
 func (s *stateV2) NFTAssetTags() (map[string]*common.Hash, error) {
 	if s.nftAssetTags == nil {
-		return nil, fmt.Errorf("NFTAssetTags missing from pdex state")
+		var err error
+		s.nftAssetTags, err = s.nftAssetTags.FromIDs(s.nftIDs)
+		if err != nil {
+			return nil, fmt.Errorf("NFTAssetTags missing from pdex state - %v", err)
+		}
 	}
 	return *s.nftAssetTags, nil
 }

--- a/blockchain/pdex/state_v2.go
+++ b/blockchain/pdex/state_v2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/incognitochain/incognito-chain/dataaccessobject/rawdbv2"
 	"github.com/incognitochain/incognito-chain/dataaccessobject/statedb"
 	"github.com/incognitochain/incognito-chain/metadata"
+	"github.com/incognitochain/incognito-chain/privacy"
 	metadataCommon "github.com/incognitochain/incognito-chain/metadata/common"
 	metadataPdexv3 "github.com/incognitochain/incognito-chain/metadata/pdexv3"
 )
@@ -810,4 +811,17 @@ func (s *stateV2) IsValidLP(poolPairID, lpID string) (bool, error) {
 		return false, fmt.Errorf("Can't not find lpID %s", lpID)
 	}
 	return true, nil
+}
+
+func (s *stateV2) NFTAssetTags() (map[string]*common.Hash, error) {
+	result := make(map[string]*common.Hash)
+	for s, _ := range s.nftIDs {
+		tokenID, err := common.Hash{}.NewHashFromStr(s)
+		if err != nil {
+			return nil, err
+		}
+		assetTag := privacy.HashToPoint(tokenID[:])
+		result[assetTag.String()] = tokenID
+	}
+	return result, nil
 }

--- a/blockchain/pdex/statedb.go
+++ b/blockchain/pdex/statedb.go
@@ -107,10 +107,15 @@ func initStateV2FromDB(
 	if err != nil {
 		return nil, err
 	}
-	return newStateV2WithValue(
+	result := newStateV2WithValue(
 		waitingContributions, make(map[string]rawdbv2.Pdexv3Contribution),
 		poolPairs, params, stakingPools, nftIDs,
-	), nil
+	)
+	result.nftAssetTags, err = result.nftAssetTags.FromIDs(nftIDs)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func initPoolPairStatesFromDB(stateDB *statedb.StateDB) (map[string]*PoolPairState, error) {

--- a/blockchain/pdex/v2utils/utils.go
+++ b/blockchain/pdex/v2utils/utils.go
@@ -203,6 +203,8 @@ func (m *NFTAssetTagsCache) FromIDs(nftIDs map[string]uint64) (*NFTAssetTagsCach
 }
 
 func (m *NFTAssetTagsCache) Add(id common.Hash) {
-	assetTag := privacy.HashToPoint(id[:])
-	(*m)[assetTag.String()] = &id
+	if m != nil {
+		assetTag := privacy.HashToPoint(id[:])
+		(*m)[assetTag.String()] = &id
+	}
 }

--- a/blockchain/pdex/v2utils/utils.go
+++ b/blockchain/pdex/v2utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/incognitochain/incognito-chain/common"
+	"github.com/incognitochain/incognito-chain/privacy"
 )
 
 type MintNftStatus struct {
@@ -179,4 +180,29 @@ func SplitOrderRewardLiquidityMining(
 	}
 
 	return orderRewards
+}
+
+type NFTAssetTagsCache map[string]*common.Hash
+
+func (m *NFTAssetTagsCache) FromIDs(nftIDs map[string]uint64) (*NFTAssetTagsCache, error) {
+	var result NFTAssetTagsCache
+	if m == nil {
+		result = make(map[string]*common.Hash)
+	} else {
+		result = *m
+	}
+	for idStr, _ := range nftIDs {
+		tokenID, err := common.Hash{}.NewHashFromStr(idStr)
+		if err != nil {
+			return nil, err
+		}
+		assetTag := privacy.HashToPoint(tokenID[:])
+		result[assetTag.String()] = tokenID
+	}
+	return &result, nil
+}
+
+func (m *NFTAssetTagsCache) Add(id common.Hash) {
+	assetTag := privacy.HashToPoint(id[:])
+	(*m)[assetTag.String()] = &id
 }

--- a/privacy/coin/coin_v2.go
+++ b/privacy/coin/coin_v2.go
@@ -554,6 +554,9 @@ func (c *CoinV2) CheckCoinValid(paymentAdd key.PaymentAddress, sharedRandom []by
 
 // Check whether the utxo is from this keyset
 func (c *CoinV2) DoesCoinBelongToKeySet(keySet *incognitokey.KeySet) (bool, *operation.Point) {
+	if keySet == nil {
+		return false, nil
+	}
 	_, txOTARandomPoint, index, err1 := c.GetTxRandomDetail()
 	if err1 != nil {
 		return false, nil

--- a/privacy/coin/coin_v2_ca.go
+++ b/privacy/coin/coin_v2_ca.go
@@ -102,7 +102,8 @@ func (coin *CoinV2) SetPlainTokenID(tokenID *common.Hash) error {
 //	- rawAssetTags: a pre-computed mapping from a raw assetTag to the tokenId (e.g, HashToPoint(PRV) => PRV).
 func (c *CoinV2) GetTokenId(keySet *incognitokey.KeySet, rawAssetTags map[string]*common.Hash) (*common.Hash, error) {
 	if c.GetAssetTag() == nil {
-		return &common.PRVCoinID, nil
+		result := common.PRVCoinID
+		return &result, nil
 	}
 
 	if asset, ok := rawAssetTags[c.GetAssetTag().String()]; ok {

--- a/privacy/privacy_exports.go
+++ b/privacy/privacy_exports.go
@@ -193,3 +193,5 @@ func NewCoinCA(info *PaymentInfo, tokenID *common.Hash) (*CoinV2, *Point, error)
 
 type TokenAttributes = privacy_v2.TokenAttributes
 var MapPlainAssetTags = privacy_v2.MapPlainAssetTags
+var ContainsNonPrivateToken = privacy_v2.ContainsNonPrivateToken
+var ValidateNonPrivateTransfer = privacy_v2.ValidateNonPrivateTransfer

--- a/privacy/privacy_exports.go
+++ b/privacy/privacy_exports.go
@@ -190,3 +190,6 @@ func ComputeAssetTagBlinder(sharedSecret *Point) (*Scalar, error) {
 func NewCoinCA(info *PaymentInfo, tokenID *common.Hash) (*CoinV2, *Point, error) {
 	return coin.NewCoinCA(info, tokenID)
 }
+
+type TokenAttributes = privacy_v2.TokenAttributes
+var MapPlainAssetTags = privacy_v2.MapPlainAssetTags

--- a/privacy/privacy_exports.go
+++ b/privacy/privacy_exports.go
@@ -195,3 +195,6 @@ type TokenAttributes = privacy_v2.TokenAttributes
 var MapPlainAssetTags = privacy_v2.MapPlainAssetTags
 var ContainsNonPrivateToken = privacy_v2.ContainsNonPrivateToken
 var ValidateNonPrivateTransfer = privacy_v2.ValidateNonPrivateTransfer
+type RingDecoyFilter = privacy_v2.RingDecoyFilter
+var NonPrivateTokenCoinFilter = privacy_v2.NonPrivateTokenCoinFilter
+type TokenIDRingDecoyFilter = privacy_v2.TokenIDRingDecoyFilter

--- a/privacy/privacy_v2/common.go
+++ b/privacy/privacy_v2/common.go
@@ -1,0 +1,21 @@
+package privacy_v2
+
+import (
+	"github.com/incognitochain/incognito-chain/common"
+	"github.com/incognitochain/incognito-chain/privacy/operation"
+)
+
+type TokenAttributes struct {
+	Private  bool
+	BurnOnly bool
+}
+
+func MapPlainAssetTags(m map[common.Hash]TokenAttributes) map[string]*common.Hash {
+	result := make(map[string]*common.Hash)
+	for id, _ := range m {
+		assetTag := operation.HashToPoint(id[:])
+		var tokenID common.Hash = id
+		result[assetTag.String()] = &tokenID
+	}
+	return result
+}

--- a/privacy/privacy_v2/common.go
+++ b/privacy/privacy_v2/common.go
@@ -1,13 +1,53 @@
 package privacy_v2
 
 import (
+	"fmt"
+
 	"github.com/incognitochain/incognito-chain/common"
+	"github.com/incognitochain/incognito-chain/privacy/coin"
 	"github.com/incognitochain/incognito-chain/privacy/operation"
+	"github.com/incognitochain/incognito-chain/privacy/proof"
+)
+
+var (
+	tokenPrivAttributeMap = initTokenPrivacyAttributes()
 )
 
 type TokenAttributes struct {
 	Private  bool
 	BurnOnly bool
+}
+
+// ValidateNonPrivateTransfer verifies TXs with identifiable inputs, based on that input's token attributes
+func ValidateNonPrivateTransfer(tokenID common.Hash, proof proof.Proof) (bool, error) {
+	att, found := tokenPrivAttributeMap[tokenID]
+	if found && att.BurnOnly {
+		// a burn-only token can only be burned
+		for _, outcoin := range proof.GetOutputCoins() {
+			receiverPk := outcoin.GetPublicKey().ToBytesS()
+			if !common.IsPublicKeyBurningAddress(receiverPk) {
+				return false, fmt.Errorf("cannot transfer burn-only token %v", tokenID)
+			}
+		}
+	}
+	return true, nil
+}
+
+// ContainsNonPrivacyToken detects a non-private coin in a ring signature
+func ContainsNonPrivateToken(ringCoins [][]*coin.CoinV2) (bool, bool, *common.Hash, *coin.CoinV2) {
+	assetTagMap := MapPlainAssetTags(tokenPrivAttributeMap)
+	for _, row := range ringCoins {
+		for _, c := range row {
+			tokenID, _ := c.GetTokenId(nil, assetTagMap) // error ignored; only relevant when keySet is present
+			if tokenID != nil {
+				att, found := tokenPrivAttributeMap[*tokenID]
+				if found && !att.Private {
+					return true, att.BurnOnly, tokenID, c
+				}
+			}
+		}
+	}
+	return false, false, nil, nil
 }
 
 func MapPlainAssetTags(m map[common.Hash]TokenAttributes) map[string]*common.Hash {
@@ -17,5 +57,11 @@ func MapPlainAssetTags(m map[common.Hash]TokenAttributes) map[string]*common.Has
 		var tokenID common.Hash = id
 		result[assetTag.String()] = &tokenID
 	}
+	return result
+}
+
+func initTokenPrivacyAttributes() map[common.Hash]TokenAttributes {
+	result := make(map[common.Hash]TokenAttributes)
+	result[common.PdexAccessCoinID] = TokenAttributes{Private: false, BurnOnly: true}
 	return result
 }

--- a/rpcserver/rpcservice/pdexv3service.go
+++ b/rpcserver/rpcservice/pdexv3service.go
@@ -193,7 +193,7 @@ func buildTokenTransaction(svc PdexTxService, sel *paramSelector) (metadataCommo
 		params.ShardIDSender, params.Info,
 		svc.BlockChain.BeaconChain.GetFinalViewState().GetBeaconFeatureStateDB(),
 	)
-
+	txTokenParams.SetRingDecoyFilters(svc.DefaultRingFilters())
 	tx := &transaction.TxTokenVersion2{}
 	errTx := tx.Init(txTokenParams)
 	if errTx != nil {

--- a/rpcserver/rpcservice/txservice.go
+++ b/rpcserver/rpcservice/txservice.go
@@ -627,6 +627,7 @@ func (txService TxService) BuildRawTransaction(
 		meta,
 		params.Info,
 	)
+	txPrivacyParams.SetRingDecoyFilters(txService.DefaultRingFilters())
 	tx, err := transaction.NewTransactionFromParams(txPrivacyParams)
 	if err != nil {
 		return nil, NewRPCError(CreateTxDataError, err)
@@ -1181,7 +1182,7 @@ func (txService TxService) BuildRawPrivacyCustomTokenTransaction(
 		txParam.HasPrivacyToken,
 		txParam.ShardIDSender, txParam.Info,
 		beaconView.GetBeaconFeatureStateDB())
-
+	txTokenParams.SetRingDecoyFilters(txService.DefaultRingFilters())
 	tx, errTx := transaction.NewTransactionTokenFromParams(txTokenParams)
 	if errTx != nil {
 		Logger.log.Errorf("Cannot create new transaction token from params, err %v", err)
@@ -1243,7 +1244,7 @@ func (txService TxService) BuildRawPrivacyCustomTokenTransactionV2(params interf
 		txParam.HasPrivacyToken,
 		txParam.ShardIDSender, txParam.Info,
 		beaconView.GetBeaconFeatureStateDB())
-
+	txTokenParams.SetRingDecoyFilters(txService.DefaultRingFilters())
 	tx, errTx := transaction.NewTransactionTokenFromParams(txTokenParams)
 	if errTx != nil {
 		Logger.log.Errorf("Cannot create new transaction token from params, err %v", err)
@@ -2223,6 +2224,7 @@ func (txService TxService) BuildRawDefragmentAccountTransaction(params interface
 		nil, // use for prv coin -> nil is valid
 		meta, nil,
 	)
+	txPrivacyParams.SetRingDecoyFilters(txService.DefaultRingFilters())
 	tx, err := transaction.NewTransactionFromParams(txPrivacyParams)
 	if err != nil {
 		return nil, NewRPCError(CreateTxDataError, err)
@@ -2578,7 +2580,7 @@ func (txService TxService) BuildRawDefragmentPrivacyCustomTokenTransaction(param
 		txParam.HasPrivacyToken,
 		txParam.ShardIDSender, txParam.Info,
 		beaconView.GetBeaconFeatureStateDB())
-
+	txTokenParams.SetRingDecoyFilters(txService.DefaultRingFilters())
 	tx, errTx := transaction.NewTransactionTokenFromParams(txTokenParams)
 	if errTx != nil {
 		Logger.log.Errorf("Cannot create new transaction token from params, err %v", err)
@@ -2599,4 +2601,16 @@ func isTxRelateCommittee(tx metadata.Transaction) bool {
 		}
 	}
 	return false
+}
+
+func (txService TxService) DefaultRingFilters() []privacy.RingDecoyFilter {
+	var result []privacy.RingDecoyFilter
+	f, err := txService.BlockChain.GetBeaconBestState().NftIDCoinFilter()
+	if err != nil {
+		Logger.log.Warnf("RPCService: NftIDCoinFilter not found, removing from default filters - %v", err)
+	} else {
+		result = append(result, f)
+	}
+	result = append(result, privacy.NonPrivateTokenCoinFilter)
+	return result
 }

--- a/transaction/tx_generic/common.go
+++ b/transaction/tx_generic/common.go
@@ -374,3 +374,30 @@ func SignNoPrivacy(privKey *privacy.PrivateKey, hashedMessage []byte) (signature
 	sigPubKey = sigKey.GetPublicKey().GetPublicKey().ToBytesS()
 	return signatureBytes, sigPubKey, nil
 }
+
+type GenericParams map[string]interface{}
+
+func NewGenericParams() *GenericParams { 
+	result := GenericParams(make(map[string]interface{}))
+	return &result
+}
+
+func (kv *GenericParams) GetKeyValueArgumentsData() map[string]interface{} {
+	if kv == nil {
+		*kv = GenericParams(make(map[string]interface{}))
+	}
+	return (map[string]interface{})(*kv)
+}
+
+func (kv *GenericParams) RingDecoyFilters() []privacy.RingDecoyFilter {
+	if value, exists := kv.GetKeyValueArgumentsData()["RingDecoyFilter"]; exists {
+		if f, ok := value.([]privacy.RingDecoyFilter); ok {
+			return f
+		}
+	}
+	return nil
+}
+
+func (kv *GenericParams) SetRingDecoyFilters(f []privacy.RingDecoyFilter) {
+	kv.GetKeyValueArgumentsData()["RingDecoyFilter"] = f
+}

--- a/transaction/tx_generic/tx_base.go
+++ b/transaction/tx_generic/tx_base.go
@@ -53,7 +53,7 @@ type TxPrivacyInitParams struct {
 	TokenID     *common.Hash // default is nil -> use for prv coin
 	MetaData    metadata.Metadata
 	Info        []byte // 512 bytes
-	Kvargs      map[string]interface{}
+	*GenericParams
 }
 
 func NewTxPrivacyInitParams(senderSK *privacy.PrivateKey,
@@ -71,16 +71,16 @@ func NewTxPrivacyInitParams(senderSK *privacy.PrivateKey,
 		info = []byte{}
 	}
 	params := &TxPrivacyInitParams{
-		StateDB:     stateDB,
-		TokenID:     tokenID,
-		HasPrivacy:  hasPrivacy,
-		InputCoins:  inputCoins,
-		Fee:         fee,
-		MetaData:    metaData,
-		PaymentInfo: paymentInfo,
-		SenderSK:    senderSK,
-		Info:        info,
-		Kvargs:      nil,
+		StateDB:       stateDB,
+		TokenID:       tokenID,
+		HasPrivacy:    hasPrivacy,
+		InputCoins:    inputCoins,
+		Fee:           fee,
+		MetaData:      metaData,
+		PaymentInfo:   paymentInfo,
+		SenderSK:      senderSK,
+		Info:          info,
+		GenericParams: NewGenericParams(),
 	}
 	return params
 }

--- a/transaction/tx_generic/tx_token_base.go
+++ b/transaction/tx_generic/tx_token_base.go
@@ -36,6 +36,7 @@ type TxTokenParams struct {
 	HasPrivacyToken    bool
 	ShardID            byte
 	Info               []byte
+	*GenericParams
 }
 
 // CustomTokenParamTx - use for rpc request json body
@@ -76,6 +77,7 @@ func NewTxTokenParams(senderKey *privacy.PrivateKey,
 		SenderKey:          senderKey,
 		TokenParams:        tokenParams,
 		Info:               info,
+		GenericParams:      NewGenericParams(),
 	}
 	return params
 }

--- a/transaction/tx_ver2/common.go
+++ b/transaction/tx_ver2/common.go
@@ -1,0 +1,76 @@
+package tx_ver2
+
+import (
+	"fmt"
+
+	"github.com/incognitochain/incognito-chain/common"
+	"github.com/incognitochain/incognito-chain/dataaccessobject/statedb"
+	"github.com/incognitochain/incognito-chain/privacy"
+	"github.com/incognitochain/incognito-chain/transaction/utils"
+)
+
+var (
+	tokenPrivAttributeMap = initTokenPrivacyAttributes()
+)
+
+func initTokenPrivacyAttributes() map[common.Hash]privacy.TokenAttributes {
+	result := make(map[common.Hash]privacy.TokenAttributes)
+	result[common.PdexAccessCoinID] = privacy.TokenAttributes{Private: false, BurnOnly: true}
+	return result
+}
+
+func getDerivableInputFromSigPubKey(rawPubkey []byte, tokenID common.Hash, txHash *common.Hash, shardID byte, db *statedb.StateDB) (*privacy.Point, error) {
+	ringPubkey := new(SigPubKey)
+	if err := ringPubkey.SetBytes(rawPubkey); err != nil {
+		return nil, utils.NewTransactionErr(utils.UnexpectedError, fmt.Errorf("invalid SigPubKey in tx %s, token %s", txHash.String(), tokenID.String()))
+	}
+	ringSize := len(ringPubkey.Indexes)
+	if ringSize != 1 || len(ringPubkey.Indexes[0]) != 1 {
+		return nil, utils.NewTransactionErr(utils.UnexpectedError, fmt.Errorf("cannot identify burn input in tx %s, token %s with ring size %d, input length %d", txHash.String(), tokenID.String(), ringSize, len(ringPubkey.Indexes[0])))
+	}
+	rawCoin, err := statedb.GetOTACoinByIndex(db, tokenID, ringPubkey.Indexes[0][0].Uint64(), shardID)
+	if err != nil {
+		return nil, utils.NewTransactionErr(utils.UnexpectedError, err)
+	}
+	c := new(privacy.CoinV2)
+	if err := c.SetBytes(rawCoin); err != nil {
+		return nil, utils.NewTransactionErr(utils.UnexpectedError, err)
+	}
+	p := c.GetPublicKey()
+	if p == nil {
+		return nil, utils.NewTransactionErr(utils.UnexpectedError, fmt.Errorf("coin from db must have public key"))
+	}
+	return p, nil
+}
+
+// validateNonPrivateTransfer verifies TXs with identifiable inputs, based on that input's token attributes
+func validateNonPrivateTransfer(tokenID common.Hash, proof privacy.Proof) (bool, error) {
+	att, found := tokenPrivAttributeMap[tokenID]
+	if found && att.BurnOnly {
+		// a burn-only token can only be burned
+		for _, outcoin := range proof.GetOutputCoins() {
+			receiverPk := outcoin.GetPublicKey().ToBytesS()
+			if !common.IsPublicKeyBurningAddress(receiverPk) {
+				return false, fmt.Errorf("cannot transfer burn-only token %v", tokenID)
+			}
+		}
+	}
+	return true, nil
+}
+
+// ringContainsNonPrivacyToken detects a non-private coin in a ring signature
+func ringContainsNonPrivacyToken(ringCoins [][]*privacy.CoinV2) (bool, bool, *common.Hash, *privacy.CoinV2) {
+	assetTagMap := privacy.MapPlainAssetTags(tokenPrivAttributeMap)
+	for _, row := range ringCoins {
+		for _, c := range row {
+			tokenID, _ := c.GetTokenId(nil, assetTagMap) // error ignored; only relevant when keySet is present
+			if tokenID != nil {
+				att := tokenPrivAttributeMap[*tokenID]
+				if !att.Private {
+					return true, att.BurnOnly, tokenID, c
+				}
+			}
+		}
+	}
+	return false, false, nil, nil
+}

--- a/transaction/tx_ver2/common.go
+++ b/transaction/tx_ver2/common.go
@@ -9,16 +9,6 @@ import (
 	"github.com/incognitochain/incognito-chain/transaction/utils"
 )
 
-var (
-	tokenPrivAttributeMap = initTokenPrivacyAttributes()
-)
-
-func initTokenPrivacyAttributes() map[common.Hash]privacy.TokenAttributes {
-	result := make(map[common.Hash]privacy.TokenAttributes)
-	result[common.PdexAccessCoinID] = privacy.TokenAttributes{Private: false, BurnOnly: true}
-	return result
-}
-
 func getDerivableInputFromSigPubKey(rawPubkey []byte, tokenID common.Hash, txHash *common.Hash, shardID byte, db *statedb.StateDB) (*privacy.Point, error) {
 	ringPubkey := new(SigPubKey)
 	if err := ringPubkey.SetBytes(rawPubkey); err != nil {
@@ -41,36 +31,4 @@ func getDerivableInputFromSigPubKey(rawPubkey []byte, tokenID common.Hash, txHas
 		return nil, utils.NewTransactionErr(utils.UnexpectedError, fmt.Errorf("coin from db must have public key"))
 	}
 	return p, nil
-}
-
-// validateNonPrivateTransfer verifies TXs with identifiable inputs, based on that input's token attributes
-func validateNonPrivateTransfer(tokenID common.Hash, proof privacy.Proof) (bool, error) {
-	att, found := tokenPrivAttributeMap[tokenID]
-	if found && att.BurnOnly {
-		// a burn-only token can only be burned
-		for _, outcoin := range proof.GetOutputCoins() {
-			receiverPk := outcoin.GetPublicKey().ToBytesS()
-			if !common.IsPublicKeyBurningAddress(receiverPk) {
-				return false, fmt.Errorf("cannot transfer burn-only token %v", tokenID)
-			}
-		}
-	}
-	return true, nil
-}
-
-// ringContainsNonPrivacyToken detects a non-private coin in a ring signature
-func ringContainsNonPrivacyToken(ringCoins [][]*privacy.CoinV2) (bool, bool, *common.Hash, *privacy.CoinV2) {
-	assetTagMap := privacy.MapPlainAssetTags(tokenPrivAttributeMap)
-	for _, row := range ringCoins {
-		for _, c := range row {
-			tokenID, _ := c.GetTokenId(nil, assetTagMap) // error ignored; only relevant when keySet is present
-			if tokenID != nil {
-				att := tokenPrivAttributeMap[*tokenID]
-				if !att.Private {
-					return true, att.BurnOnly, tokenID, c
-				}
-			}
-		}
-	}
-	return false, false, nil, nil
 }

--- a/transaction/tx_ver2/tx_token_ver2.go
+++ b/transaction/tx_ver2/tx_token_ver2.go
@@ -324,6 +324,7 @@ func (txToken *TxToken) initToken(txNormal *Tx, params *tx_generic.TxTokenParams
 				nil,
 				nil,
 			)
+			txParams.GenericParams = params.GenericParams
 			isBurning, err := txNormal.proveToken(txParams)
 			if err != nil {
 				return utils.NewTransactionErr(utils.PrivacyTokenInitTokenDataError, err)

--- a/transaction/tx_ver2/tx_token_ver2.go
+++ b/transaction/tx_ver2/tx_token_ver2.go
@@ -605,7 +605,7 @@ func (txToken *TxToken) verifySig(transactionStateDB *statedb.StateDB, shardID b
 
 	// Reform Ring
 	sumOutputCoinsWithFee := tx_generic.CalculateSumOutputsWithFee(txFee.GetProof().GetOutputCoins(), txFee.GetTxFee())
-	ring, err := getRingFromSigPubKeyAndLastColumnCommitmentV2(txFee.GetValidationEnv(), sumOutputCoinsWithFee, transactionStateDB)
+	ring, _, err := getRingFromSigPubKeyAndLastColumnCommitmentV2(txFee.GetValidationEnv(), sumOutputCoinsWithFee, transactionStateDB)
 	if err != nil {
 		utils.Logger.Log.Errorf("Error when querying database to construct mlsag ring: %v ", err)
 		return false, err

--- a/transaction/tx_ver2/tx_ver2.go
+++ b/transaction/tx_ver2/tx_ver2.go
@@ -400,7 +400,7 @@ func (tx *Tx) verifySig(transactionStateDB *statedb.StateDB, shardID byte, token
 	case privacy.RingSize:
 		// private PRV transfer
 	case 1:
-		if valid, err := validateNonPrivateTransfer(common.PRVCoinID, tx.GetProof()); !valid {
+		if valid, err := privacy.ValidateNonPrivateTransfer(common.PRVCoinID, tx.GetProof()); !valid {
 			return false, fmt.Errorf("invalid non-private transfer - %v", err)
 		}
 	default:

--- a/transaction/tx_ver2/tx_ver2_ca.go
+++ b/transaction/tx_ver2/tx_ver2_ca.go
@@ -414,7 +414,7 @@ func (tx *Tx) verifySigCA(transactionStateDB *statedb.StateDB, shardID byte, tok
 		utils.Logger.Log.Errorf("Error when querying database to construct mlsag ring: %v ", err)
 		return false, err
 	}
-	hasNonPrivateCoin, _, nptoken, npcoin := ringContainsNonPrivacyToken(coinsInRing)
+	hasNonPrivateCoin, _, nptoken, npcoin := privacy.ContainsNonPrivateToken(coinsInRing)
 	switch len(coinsInRing) {
 	case privacy.RingSize:
 		if hasNonPrivateCoin {
@@ -426,7 +426,7 @@ func (tx *Tx) verifySigCA(transactionStateDB *statedb.StateDB, shardID byte, tok
 		if hasNonPrivateCoin {
 			tokenID = *nptoken
 		}
-		if valid, err := validateNonPrivateTransfer(tokenID, tx.GetProof()); !valid {
+		if valid, err := privacy.ValidateNonPrivateTransfer(tokenID, tx.GetProof()); !valid {
 			return false, fmt.Errorf("invalid non-private token transfer - %v", err)
 		}
 	default:

--- a/transaction/tx_ver2/tx_ver2_ca_newpool.go
+++ b/transaction/tx_ver2/tx_ver2_ca_newpool.go
@@ -11,11 +11,11 @@ import (
 	"github.com/incognitochain/incognito-chain/transaction/utils"
 )
 
-func reconstructRingCAV2(txEnv metadata.ValidationEnviroment, sumOutputsWithFee, sumOutputAssetTags *privacy.Point, numOfOutputs *privacy.Scalar, transactionStateDB *statedb.StateDB) (*mlsag.Ring, error) {
+func reconstructRingCAV2(txEnv metadata.ValidationEnviroment, sumOutputsWithFee, sumOutputAssetTags *privacy.Point, numOfOutputs *privacy.Scalar, transactionStateDB *statedb.StateDB) (*mlsag.Ring, [][]*privacy.CoinV2, error) {
 	txSigPubKey := new(SigPubKey)
 	if err := txSigPubKey.SetBytes(txEnv.SigPubKey()); err != nil {
 		errStr := fmt.Sprintf("Error when parsing bytes of txSigPubKey %v", err)
-		return nil, utils.NewTransactionErr(utils.UnexpectedError, errors.New(errStr))
+		return nil, nil, utils.NewTransactionErr(utils.UnexpectedError, errors.New(errStr))
 	}
 	indexes := txSigPubKey.Indexes
 	n := len(indexes)
@@ -25,29 +25,38 @@ func reconstructRingCAV2(txEnv metadata.ValidationEnviroment, sumOutputsWithFee,
 
 	m := len(indexes[0])
 	OTAData := txEnv.DBData()
+	if m*n != len(OTAData) {
+		return nil, nil, fmt.Errorf("Cached OTA data not match with indexes")
+	}
 	ring := make([][]*privacy.Point, n)
+	coinsInRing := make([][]*privacy.CoinV2, n)
+	
 	for i := 0; i < n; i++ {
 		sumCommitment := new(privacy.Point).Identity()
 		sumCommitment.Sub(sumCommitment, sumOutputsWithFee)
 		sumAssetTags := new(privacy.Point).Identity()
 		sumAssetTags.Sub(sumAssetTags, sumOutputAssetTags)
 		row := make([]*privacy.Point, m+2)
+		coinsInRing[i] = make([]*privacy.CoinV2, m)
+
 		for j := 0; j < m; j++ {
 			randomCoinBytes := OTAData[i*m+j]
 			randomCoin := new(privacy.CoinV2)
 			if err := randomCoin.SetBytes(randomCoinBytes); err != nil {
 				utils.Logger.Log.Errorf("Set coin Byte error %v ", err)
-				return nil, err
+				return nil, nil, err
 			}
 			row[j] = randomCoin.GetPublicKey()
 			sumCommitment.Add(sumCommitment, randomCoin.GetCommitment())
 			temp := new(privacy.Point).ScalarMult(randomCoin.GetAssetTag(), numOfOutputs)
 			sumAssetTags.Add(sumAssetTags, temp)
+
+			coinsInRing[i][j] = randomCoin
 		}
 
 		row[m] = new(privacy.Point).Set(sumAssetTags)
 		row[m+1] = new(privacy.Point).Set(sumCommitment)
 		ring[i] = row
 	}
-	return mlsag.NewRing(ring), nil
+	return mlsag.NewRing(ring), coinsInRing, nil
 }

--- a/transaction/tx_ver2/tx_ver2_ca_newpool.go
+++ b/transaction/tx_ver2/tx_ver2_ca_newpool.go
@@ -20,7 +20,7 @@ func reconstructRingCAV2(txEnv metadata.ValidationEnviroment, sumOutputsWithFee,
 	indexes := txSigPubKey.Indexes
 	n := len(indexes)
 	if n == 0 {
-		return nil, errors.New("Cannot get ring from Indexes: Indexes is empty")
+		return nil, nil, errors.New("Cannot get ring from Indexes: Indexes is empty")
 	}
 
 	m := len(indexes[0])

--- a/transaction/tx_ver2/tx_ver2_newpool.go
+++ b/transaction/tx_ver2/tx_ver2_newpool.go
@@ -105,7 +105,7 @@ func getRingFromSigPubKeyAndLastColumnCommitmentV2(txEnv metadata.ValidationEnvi
 	OTAData := txEnv.DBData()
 	n := len(indexes)
 	if n == 0 {
-		return nil, errors.New("Cannot get ring from Indexes: Indexes is empty")
+		return nil, nil, errors.New("Cannot get ring from Indexes: Indexes is empty")
 	}
 	m := len(indexes[0])
 	if m*n != len(OTAData) {

--- a/transaction/tx_ver2/tx_ver2_newpool.go
+++ b/transaction/tx_ver2/tx_ver2_newpool.go
@@ -95,11 +95,11 @@ func (tx *Tx) VerifySigTx(transactionStateDB *statedb.StateDB) (bool, error) {
 }
 
 // Retrieve ring from database using sigpubkey and last column commitment (last column = sumOutputCoinCommitment + fee)
-func getRingFromSigPubKeyAndLastColumnCommitmentV2(txEnv metadata.ValidationEnviroment, sumOutputsWithFee *privacy.Point, transactionStateDB *statedb.StateDB) (*mlsag.Ring, error) {
+func getRingFromSigPubKeyAndLastColumnCommitmentV2(txEnv metadata.ValidationEnviroment, sumOutputsWithFee *privacy.Point, transactionStateDB *statedb.StateDB) (*mlsag.Ring, [][]*privacy.CoinV2, error) {
 	txSigPubKey := new(SigPubKey)
 	if err := txSigPubKey.SetBytes(txEnv.SigPubKey()); err != nil {
 		errStr := fmt.Sprintf("Error when parsing bytes of txSigPubKey %v", err)
-		return nil, utils.NewTransactionErr(utils.UnexpectedError, errors.New(errStr))
+		return nil, nil, utils.NewTransactionErr(utils.UnexpectedError, errors.New(errStr))
 	}
 	indexes := txSigPubKey.Indexes
 	OTAData := txEnv.DBData()
@@ -109,28 +109,33 @@ func getRingFromSigPubKeyAndLastColumnCommitmentV2(txEnv metadata.ValidationEnvi
 	}
 	m := len(indexes[0])
 	if m*n != len(OTAData) {
-		return nil, errors.Errorf("Cached OTA data not match with indexes")
+		return nil, nil, errors.Errorf("Cached OTA data not match with indexes")
 	}
-
 	ring := make([][]*privacy.Point, n)
+	coinsInRing := make([][]*privacy.CoinV2, n)
+
 	for i := 0; i < n; i++ {
 		sumCommitment := new(privacy.Point).Identity()
 		sumCommitment.Sub(sumCommitment, sumOutputsWithFee)
 		row := make([]*privacy.Point, m+1)
+		coinsInRing[i] = make([]*privacy.CoinV2, m)
+
 		for j := 0; j < m; j++ {
 			randomCoinBytes := OTAData[i*m+j]
 			randomCoin := new(privacy.CoinV2)
 			if err := randomCoin.SetBytes(randomCoinBytes); err != nil {
 				utils.Logger.Log.Errorf("Set coin Byte error %v ", err)
-				return nil, err
+				return nil, nil, err
 			}
 			row[j] = randomCoin.GetPublicKey()
 			sumCommitment.Add(sumCommitment, randomCoin.GetCommitment())
+
+			coinsInRing[i][j] = randomCoin
 		}
 		row[m] = new(privacy.Point).Set(sumCommitment)
 		ring[i] = row
 	}
-	return mlsag.NewRing(ring), nil
+	return mlsag.NewRing(ring), coinsInRing, nil
 }
 
 // Retrieve ring from database using sigpubkey and last column commitment (last column = sumOutputCoinCommitment + fee)


### PR DESCRIPTION
In this PR:
- update TX ring signing in fullnode
  - no longer pick NFTID coins
  - handling for non-private tokens / burn-only tokens
    - they cannot be added to standard ring
    - burn-only input tokens have their receiver verified (must be burning address)
- update "randomcommitmentandpublickeys" RPC method
  - upon reading unwanted random coin, retry with `max_attempts` instead of indefinitely