### PR TITLE
[hotfix] Sort committee before process salary instruction

### DIFF
--- a/dataaccessobject/statedb/statedb.go
+++ b/dataaccessobject/statedb/statedb.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"sort"
 	"strconv"
 	"time"
 
@@ -864,6 +865,9 @@ func (stateDB *StateDB) getShardsCommitteeInfo(curValidator map[int][]*Committee
 func (stateDB *StateDB) getShardsCommitteeInfoV2(curValidator map[int][]*CommitteeState) (curValidatorInfo map[int][]*StakerInfoSlashingVersion) {
 	curValidatorInfo = make(map[int][]*StakerInfoSlashingVersion)
 	for shardID, listCommittee := range curValidator {
+		sort.Slice(listCommittee, func(i, j int) bool {
+			return listCommittee[i].EnterTime() < listCommittee[j].EnterTime()
+		})
 		tempStakerInfos := []*StakerInfoSlashingVersion{}
 		for _, c := range listCommittee {
 			cPKBytes, _ := c.committeePublicKey.RawBytes()


### PR DESCRIPTION
Committee list need to be sort by enter_time to maintain its index before process salary instruction