### PR TITLE
Dev/pv2 rpc extend

### DIFF
--- a/rpcserver/rpcservice/outputcoinservice.go
+++ b/rpcserver/rpcservice/outputcoinservice.go
@@ -579,6 +579,7 @@ func (coinService CoinService) GetOutputCoinByIndex(tokenID common.Hash, idxList
 		}
 
 		outCoin := jsonresult.NewOutCoin(otaCoin)
+		outCoin.Index = base58.Base58Check{}.Encode(new(big.Int).SetUint64(idx).Bytes(), 0)
 
 		result[idx] = outCoin
 	}

--- a/rpcserver/rpcservice/txservice.go
+++ b/rpcserver/rpcservice/txservice.go
@@ -2,6 +2,7 @@ package rpcservice
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,6 +89,7 @@ func (txService TxService) ListCommitmentIndices(tokenID common.Hash, shardID by
 	return statedb.ListCommitmentIndices(transactionStateDB, tokenID, shardID)
 }
 
+// HasSerialNumbers checks if a list of serial numbers have been spent. The serial number list can either be base58- or base64-encoded.
 func (txService TxService) HasSerialNumbers(shardID byte, serialNumbersStr []interface{}, tokenID common.Hash) ([]bool, error) {
 	if int(shardID) >= common.MaxShardNumber {
 		return nil, fmt.Errorf("shardID %v is out of range [0 - %v]", shardID, common.MaxShardNumber-1)
@@ -96,11 +98,14 @@ func (txService TxService) HasSerialNumbers(shardID byte, serialNumbersStr []int
 	for _, item := range serialNumbersStr {
 		itemStr, okParam := item.(string)
 		if !okParam {
-			return nil, fmt.Errorf("Invalid serial number param, %+v", item)
+			return nil, fmt.Errorf("invalid serial number param, %+v", item)
 		}
 		serialNumber, _, err := base58.Base58Check{}.Decode(itemStr)
 		if err != nil {
-			return nil, fmt.Errorf("Decode serial number failed, %+v", itemStr)
+			serialNumber, err = base64.StdEncoding.DecodeString(itemStr)
+			if err != nil {
+				return nil, fmt.Errorf("decode serial number failed, %+v", itemStr)
+			}
 		}
 		transactionStateDB := txService.BlockChain.GetBestStateShard(shardID).GetCopiedTransactionStateDB()
 		ok, err := statedb.HasSerialNumber(transactionStateDB, tokenID, serialNumber, shardID)


### PR DESCRIPTION
- Updated `getotacoinsbyindices` RPC: 
  - added params `FromIndex` and `ToIndex` to query from a range
  - added index when returning the queried coins
- Updated `hasserialnumbers` RPC: allow base64-encoded serial numbers as the parameters.
