### PR TITLE
Liquidity verbosity for pdexv3State/PoolPairs RPC

### DIFF
--- a/blockchain/pdex/statedb.go
+++ b/blockchain/pdex/statedb.go
@@ -309,6 +309,33 @@ func InitIntermediatePoolPairStatesFromDB(stateDB *statedb.StateDB) (map[string]
 	return res, nil
 }
 
+func InitLiquidityPoolPairStatesFromDB(stateDB *statedb.StateDB) (map[string]*PoolPairState, error) {
+	res := make(map[string]*PoolPairState)
+	poolPairsStates, err := statedb.GetPdexv3PoolPairs(stateDB)
+	if err != nil {
+		return nil, err
+	}
+	for poolPairID, poolPairState := range poolPairsStates {
+		orderbook := &Orderbook{[]*Order{}}
+		orderMap, err := statedb.GetPdexv3Orders(stateDB, poolPairID)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range orderMap {
+			v := item.Value()
+			orderbook.InsertOrder(&v)
+		}
+
+		poolPair := NewPoolPairStateWithValue(
+			poolPairState.Value(), nil, *orderbook,
+			nil, nil, nil, nil,
+			nil, nil, nil,
+		)
+		res[poolPairID] = poolPair
+	}
+	return res, nil
+}
+
 func InitFullPoolPairStatesFromDB(stateDB *statedb.StateDB) (map[string]*PoolPairState, error) {
 	res := make(map[string]*PoolPairState)
 	poolPairsStates, err := statedb.GetPdexv3PoolPairs(stateDB)

--- a/rpcserver/rpcservice/constants.go
+++ b/rpcserver/rpcservice/constants.go
@@ -16,4 +16,5 @@ const (
 	SimpleVerbosity      = 1
 	IntermidateVerbosity = 2
 	FullVerbosity        = 3
+	LiquidityVerbosity   = 4
 )

--- a/rpcserver/rpcservice/pdexv3service.go
+++ b/rpcserver/rpcservice/pdexv3service.go
@@ -535,6 +535,16 @@ func getPdexv3PoolPairs(
 			PoolPairs:       &poolPairStates,
 		}
 		return res, nil
+	case LiquidityVerbosity:
+		poolPairStates, err := pdex.InitLiquidityPoolPairStatesFromDB(stateDB)
+		if err != nil {
+			return nil, NewRPCError(GetPdexv3StateError, err)
+		}
+		res := &jsonresult.Pdexv3State{
+			BeaconTimeStamp: beaconTimeStamp,
+			PoolPairs:       &poolPairStates,
+		}
+		return res, nil		
 	default:
 		return nil, NewRPCError(GetPdexv3StateError, errors.New("Can't recognize verbosity"))
 	}


### PR DESCRIPTION
Current verbosity levels do not help traders effectively. Either she has to get full state object or aggregate the required state by calling multiple RPCs. PR removes this dilemma.